### PR TITLE
Rewrite README to reflect full capabilities and future vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
                (in peril)
 ```
 
-Generate labeled wallpapers for macOS workspaces.
+A workspace identity system for macOS. Generate labeled wallpapers, navigate between desktops by name, and position apps into zones — all from a single config file.
 
-**What's a workspace?** macOS lets you create multiple desktops called "Spaces" (swipe left/right with three fingers, or ctrl+←/→). But Apple doesn't let you name them - so this tool generates wallpapers with labels to identify each one.
+macOS doesn't let you name Spaces. This tool fixes that.
+
+<!-- TODO: Add a hero screenshot here showing 3-4 different workspaces side by side,
+     ideally showing different visual styles (classic, diagonal, typography).
+     Recommended size: 1200px wide, PNG or WebP. -->
 
 ## Quick Start
 
@@ -38,74 +42,285 @@ wp tutorial
 ## Usage
 
 ```bash
-wp                # Apply wallpaper (picker or --all)
+wp                # Apply wallpapers (picker or --all)
 wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
-wp goto -         # Go back to previous workspace
+wp goto -         # Go back to previous workspace (like cd -)
 ```
+
+## Visual Styles
+
+Every wallpaper can use one of six visual styles. Set per-workspace in your config or pick interactively with `wp generate`.
+
+| Style | Description |
+|-------|-------------|
+| `classic` | Clean and minimal. Optional watermark and border text. |
+| `diagonal` | 30° diagonal tiling — luxury fashion-brand aesthetic. |
+| `tiled` | Dense 75° wall-to-wall typography texture. |
+| `typography` | Scattered multi-layer composition. Design poster feel. |
+| `flowfield` | Organic noise-driven flowing lines. Topographic texture. |
+| `perspective` | Experimental ray simulation with obstacle physics. |
+
+All procedural styles use seeded randomness — same workspace name always produces the same output.
+
+<!-- TODO: Add a 2x3 grid of style previews here. Generate one wallpaper per style
+     with the same name (e.g., "Code") and same background color, so the style
+     differences are clear. Recommended: 600x400px per cell, or one combined image. -->
+
+## Multi-Zone Layouts
+
+A single wallpaper can contain multiple zones — split your desktop visually to match how you use it. Zones use flex proportions (like CSS flexbox) with configurable gaps and rounded corners.
+
+<!-- TODO: Add a screenshot of a multi-zone wallpaper, e.g., a 2:1 split
+     with "Code" on the left and "Browser" on the right. -->
+
+```json
+{
+  "spaces": [
+    {
+      "zones": [
+        { "name": "Code", "bgColor": "#1a1a2e", "style": "classic", "flex": 2 },
+        { "name": "Browser", "bgColor": "#0f3460", "style": "diagonal", "flex": 1 }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ]
+}
+```
+
+## App Positioning
+
+With [Hammerspoon](https://www.hammerspoon.org/) installed, `wp apply` goes beyond wallpapers — it positions your apps into zones automatically. Define which apps go where in your config, and your entire workspace layout is applied in one command.
+
+```json
+{
+  "zones": [
+    {
+      "name": "Code",
+      "flex": 2,
+      "apps": ["Code", "Terminal"]
+    },
+    {
+      "name": "Reference",
+      "flex": 1,
+      "apps": ["Safari"]
+    }
+  ]
+}
+```
+
+```bash
+wp apply              # Apply wallpapers + position apps
+wp apply --apps       # Only reposition apps
+wp apply:undo         # Undo app positioning
+```
+
+Your workspace is now code. Version it, share it, reproduce it.
+
+## Workspace Navigation
+
+Navigate between spaces by name instead of swiping. The `goto` command supports a `cd -` style shortcut to jump back to where you were.
+
+```bash
+wp goto code          # Switch to "Code" workspace
+wp goto               # Show picker
+wp goto -             # Jump back to previous workspace
+```
+
+Workspaces are matched by ID, slug, or name (case-insensitive). If your workspace is named "Skydiving 🪂" with `"id": "skydiving"`, both `wp goto skydiving` and the full name work.
 
 ## Config
 
-Create your config with `wp config:init`, then edit with `wp config:edit`:
+Create your config with `wp config:init`, then edit with `wp config:edit`.
+
+**Simple format** — one zone per space:
 
 ```json
 {
   "workspaces": [
     { "name": "Personal", "bgColor": "#2d3436" },
-    { "name": "Code", "bgColor": "#1a1a2e", "description": "Dev environment" },
-    { "name": "Design", "bgColor": "#0f3460" }
+    { "name": "Code", "bgColor": "#1a1a2e", "description": "Dev environment", "style": "diagonal" },
+    { "name": "Design", "bgColor": "#0f3460", "style": "typography" },
+    { "name": "Skydiving 🪂", "id": "skydiving", "bgColor": "#6c5ce7" }
   ],
   "defaults": {
     "bgColor": "#000000",
-    "textColor": "#ffffff"
+    "textColor": "#ffffff",
+    "style": "classic"
   }
 }
 ```
 
-The order of workspaces matches your Spaces order (left to right).
+**Full format** — multi-zone spaces with app positioning:
 
-## Features
+```json
+{
+  "spaces": [
+    {
+      "zones": [
+        {
+          "name": "Code",
+          "description": "Development",
+          "bgColor": "#1a1a2e",
+          "style": "classic",
+          "watermark": true,
+          "flex": 2,
+          "apps": ["Code"]
+        },
+        {
+          "name": "Docs",
+          "bgColor": "#0f3460",
+          "style": "diagonal",
+          "flex": 1,
+          "apps": ["Safari"]
+        }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ],
+  "defaults": {
+    "bgColor": "#000000",
+    "textColor": "#ffffff",
+    "style": "classic"
+  }
+}
+```
 
-- **Native Swift** - Core Graphics rendering, no external dependencies
-- **Auto-detect resolution** - Fits your screen perfectly
-- **LTR/RTL support** - Works with English, Hebrew, Arabic, etc.
-- **Space navigation** - Switch workspaces by name
+Config location: `~/.config/wallpapers/config.json`
 
-## Requirements
+The workspace order matches your macOS Spaces order (left to right). Both formats are supported — the legacy format is auto-converted internally.
 
-- macOS 13+
-- [mise](https://mise.jdx.dev/) (installs other dependencies automatically)
+**Workspace IDs:** Each workspace gets a filename-safe slug derived from its name (lowercase, spaces→hyphens, alphanumeric only). Use the `id` field to override, especially for names with emojis or special characters.
 
 ## All Commands
 
 | Command | Description |
 |---------|-------------|
-| `wp` | Apply wallpaper (shows picker, or use `--all`) |
-| `wp quick` | Quick generate - just enter a name |
+| `wp` | Apply wallpapers + apps (shows picker, or use `--all`) |
+| `wp quick` | Quick generate — just enter a name |
 | `wp goto [name]` | Switch workspace (picker if no name) |
 | `wp goto -` | Go back to previous workspace |
 | `wp generate` | Full interactive generator with all options |
+| `wp cli "Name" [options]` | Direct generation without prompts |
 | `wp config:init` | Create starter config |
 | `wp config:edit` | Open config in editor |
+| `wp apply:undo` | Undo app positioning |
 | `wp info:space` | Show current desktop number |
+| `wp info:resolution` | Show screen resolution |
 | `wp info:list` | List generated wallpapers |
+| `wp info:wallpaper` | Show current wallpaper path |
+| `wp hammerspoon:config` | Generate Hammerspoon integration config |
 | `wp clean` | Delete all generated wallpapers |
 | `wp tutorial` | Interactive tutorial |
 
-## Advanced
+## Scripting & CLI Reference
 
-For scripting or direct access:
+For scripting or direct access, bypass the interactive prompts:
 
 ```bash
-swift src/generate.swift "Name" [options]
-  -d, --description    Subtitle text
-  -r, --resolution     Preset: 1080p, 1440p, 4k, macbook-14, macbook-16, imac-24, studio-display
-  --width, --height    Custom dimensions
-  --bg-color           Background hex color
-  --text-color         Text hex color
+swift run generate "Name" [options]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `-d, --description` | Subtitle text |
+| `-r, --resolution` | Preset: `1080p`, `1440p`, `4k`, `macbook-14`, `macbook-16`, `imac-24`, `studio-display` |
+| `--width, --height` | Custom dimensions |
+| `--bg-color` | Background hex color (`#RRGGBB`) |
+| `--text-color` | Text hex color (`#RRGGBB`) |
+| `--id` | Override filename slug |
+| `--index` | Space index number |
+| `--style` | Visual style (see [Visual Styles](#visual-styles)) |
+| `--watermark` | Enable center watermark (classic style) |
+| `--border-text` | Enable border text (classic style) |
+| `--watermark-opacity` | Watermark opacity (0.0–1.0) |
+| `--border-opacity` | Border text opacity (0.0–1.0) |
+| `--gradient-opacity` | Bottom gradient opacity (0.0–1.0) |
+| `-o, --output-dir` | Output directory |
+
+Resolution presets:
+
+```
+1080p: 1920×1080       macbook-14: 3024×1964
+1440p: 2560×1440       macbook-16: 3456×2234
+4k:    3840×2160       imac-24:    4480×2520
+                       studio-display: 5120×2880
+```
+
+## Agent Integration
+
+This tool is designed to be used by both humans and AI agents. The `wp ai` command outputs structured context about the tool's capabilities, config format, and available commands — suitable for feeding into an LLM or agent system.
+
+If you're building an agent that manages workspaces, you can:
+
+1. Read the config programmatically (`~/.config/wallpapers/config.json`)
+2. Generate wallpapers via the CLI (`wp cli "Name" --bg-color "#1a1a2e" --style diagonal`)
+3. Apply to spaces (`wp apply --all`)
+4. Navigate spaces (`wp goto <name>`)
+
+All commands are non-interactive when given explicit arguments, making them safe for automated pipelines.
+
+<!-- TODO: Add an example of an agent workflow — e.g., a script that reads a
+     project manifest and creates workspace configs automatically. -->
+
+## Architecture
+
+**Swift library + bash orchestration.** The core rendering lives in `WallpaperKit` (pure Swift, Core Graphics, zero external dependencies). Bash tasks in `.mise/tasks/` handle user interaction, state management, and macOS integration via `osascript` and Hammerspoon.
+
+```
+Sources/
+├── WallpaperKit/          # Core library — rendering, styles, layout
+│   ├── Generator.swift    # Wallpaper + multi-zone rendering
+│   ├── Style.swift        # Style enum
+│   ├── Styles/            # Style implementations (diagonal, flowfield, etc.)
+│   ├── Colors.swift       # Hex parsing, luminance, contrast
+│   ├── Noise.swift        # Seeded RNG + 2D noise for procedural styles
+│   └── ...
+├── generate/main.swift    # CLI: single wallpaper
+├── setup/main.swift       # CLI: batch generation from config
+└── playground/main.swift  # Experimental ray simulation sandbox
+```
+
+Key design decisions:
+- **Deterministic output** — all procedural generation is seeded from workspace name
+- **No external dependencies** — only Apple frameworks (AppKit, Core Graphics, Core Text, ImageIO)
+- **Backward-compatible config** — legacy single-zone format auto-converts to the new multi-zone format
+- **Private APIs for space detection** — `CGSCopyManagedDisplaySpaces()` and `CGSGetActiveSpace()` are undocumented; may break in future macOS versions
+
+## Roadmap
+
+Where this project could go next.
+
+### Visual Styles
+- **More generative styles** — voronoi diagrams, gradient mesh, particle systems. The style system is a clean enum + render function; adding new styles is straightforward.
+- **Style parameters in config** — expose angles, opacities, densities, and noise scales as per-workspace config options for fine-grained customization.
+- **Theme system** — named color palettes (nord, dracula, solarized, catppuccin) that can be applied across all workspaces with a single setting.
+
+### Workspace Templates
+- **Pre-built configs** for common workflows: developer (code + terminal + browser), designer (figma + preview + reference), writer (editor + research + notes).
+- **Shareable templates** — publish and install workspace configs like dotfiles. `wp template:install developer-dark`.
+
+### Platform Support
+- **Multi-monitor** — per-display configs. The resolution system and multi-zone layout already handle arbitrary dimensions; per-display workspace definitions would be the next step.
+- **Linux / Wayland** — the rendering concepts (labeled wallpapers, workspace navigation) apply directly. Port the rendering to Cairo or Skia, use `swaymsg` / `wmctrl` for workspace switching.
+- **Windows** — Windows 10+ virtual desktops are accessible via the `IVirtualDesktopManager` COM interface. Wallpaper setting via `SystemParametersInfo` or registry. Rendering via Direct2D or cross-platform Skia backend. Space detection is actually better-documented than on macOS.
+
+### App & Integration
+- **Menu bar app** — the Swift core is already a library (`WallpaperKit`). Wrapping it in a lightweight menu bar app would enable quick switching, regeneration, and preview without the terminal.
+- **Config hot-reload** — watch the config file with FSEvents and regenerate wallpapers on change. Edit your config, see the result instantly.
+- **Animated wallpapers** — the ray simulation already generates paths over time. Rendering to HEIC sequences or video for dynamic wallpapers is a short step from here.
+
+## Requirements
+
+- macOS 13+
+- [mise](https://mise.jdx.dev/) (installs gum and other tools automatically)
+- [Hammerspoon](https://www.hammerspoon.org/) (optional, for app positioning and space navigation)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wallpapers
+<div align="center">
 
 ```
          ▲ ▲
@@ -9,17 +9,53 @@
       ╱╱    ╲╲        ◀═══╯
      ╱╱  ╱╲  ╲╲
     ▔▔  ▔▔▔▔  ▔▔
-   ZERGLING    TURTLE
-               (in peril)
 ```
 
-A workspace identity system for macOS. Generate labeled wallpapers, navigate between desktops by name, and position apps into zones — all from a single config file.
+# Wallpapers
 
-macOS doesn't let you name Spaces. This tool fixes that.
+**A workspace identity system for macOS.**
 
-<!-- TODO: Add a hero screenshot here showing 3-4 different workspaces side by side,
-     ideally showing different visual styles (classic, diagonal, typography).
-     Recommended size: 1200px wide, PNG or WebP. -->
+Generate labeled wallpapers. Navigate desktops by name. Position apps into zones.
+All from a single config file.
+
+[![Swift 5.9+](https://img.shields.io/badge/Swift-5.9+-F05138?logo=swift&logoColor=white)](https://swift.org)
+[![macOS 13+](https://img.shields.io/badge/macOS-13+-000000?logo=apple&logoColor=white)](https://www.apple.com/macos/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Zero Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](Package.swift)
+[![Agent Ready](https://img.shields.io/badge/agent-ready-8A2BE2)](#agent-integration)
+
+</div>
+
+<!-- ┌─────────────────────────────────────────────────────────────────┐
+     │  HERO IMAGE                                                    │
+     │                                                                │
+     │  Generate this by running:                                     │
+     │    wp cli "Personal" --bg-color "#2d3436" --style classic      │
+     │    wp cli "Code" --bg-color "#1a1a2e" --style diagonal         │
+     │    wp cli "Design" --bg-color "#0f3460" --style typography     │
+     │    wp cli "Music" --bg-color "#6c5ce7" --style flowfield       │
+     │                                                                │
+     │  Then stitch them into a single 1400×400 image with a slight  │
+     │  perspective tilt (like cards fanning out). Save as:           │
+     │    docs/assets/hero.png                                        │
+     │                                                                │
+     │  Tip: Add a subtle drop shadow under each wallpaper and use   │
+     │  a transparent or #0d1117 background to match GitHub dark.     │
+     └─────────────────────────────────────────────────────────────────┘ -->
+
+<p align="center">
+  <img src="docs/assets/hero.png" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width="800" />
+</p>
+
+<br />
+
+## Why?
+
+macOS lets you create multiple desktops — Apple calls them **Spaces**. You can swipe between them or use `ctrl+←/→`. But Apple doesn't let you name them. After three desktops they all look the same.
+
+This tool generates wallpapers with labels so you always know where you are. But it goes further: it's a full workspace-as-code system with navigation, app layout, and generative art.
+
+<br />
 
 ## Quick Start
 
@@ -39,6 +75,8 @@ source ~/.zshrc
 wp tutorial
 ```
 
+<br />
+
 ## Usage
 
 ```bash
@@ -47,34 +85,83 @@ wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
-wp goto -         # Go back to previous workspace (like cd -)
+wp goto -         # Go back (like cd -)
 ```
+
+<br />
 
 ## Visual Styles
 
-Every wallpaper can use one of six visual styles. Set per-workspace in your config or pick interactively with `wp generate`.
+Six built-in styles — from minimal to generative art. Set per-workspace in config or pick interactively with `wp generate`.
 
-| Style | Description |
-|-------|-------------|
-| `classic` | Clean and minimal. Optional watermark and border text. |
-| `diagonal` | 30° diagonal tiling — luxury fashion-brand aesthetic. |
-| `tiled` | Dense 75° wall-to-wall typography texture. |
-| `typography` | Scattered multi-layer composition. Design poster feel. |
-| `flowfield` | Organic noise-driven flowing lines. Topographic texture. |
-| `perspective` | Experimental ray simulation with obstacle physics. |
+<!-- ┌─────────────────────────────────────────────────────────────────┐
+     │  STYLE GRID                                                    │
+     │                                                                │
+     │  Generate all 6 with the same name + color for comparison:     │
+     │    for s in classic diagonal tiled typography flowfield         │
+     │      perspective; do                                           │
+     │      wp cli "Code" --bg-color "#1a1a2e" --style $s \           │
+     │        --resolution 1080p --id "style-$s"                      │
+     │    done                                                        │
+     │                                                                │
+     │  Arrange as 3×2 grid, ~400×250 each. Save as:                 │
+     │    docs/assets/styles.png                                      │
+     │                                                                │
+     │  Add style name as a small label below each cell.              │
+     └─────────────────────────────────────────────────────────────────┘ -->
 
-All procedural styles use seeded randomness — same workspace name always produces the same output.
+<p align="center">
+  <img src="docs/assets/styles.png" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width="700" />
+</p>
 
-<!-- TODO: Add a 2x3 grid of style previews here. Generate one wallpaper per style
-     with the same name (e.g., "Code") and same background color, so the style
-     differences are clear. Recommended: 600x400px per cell, or one combined image. -->
+<table>
+  <tr>
+    <td><strong><code>classic</code></strong></td>
+    <td>Clean and minimal. Optional watermark and border text.</td>
+  </tr>
+  <tr>
+    <td><strong><code>diagonal</code></strong></td>
+    <td>30° diagonal tiling — luxury fashion-brand aesthetic.</td>
+  </tr>
+  <tr>
+    <td><strong><code>tiled</code></strong></td>
+    <td>Dense 75° wall-to-wall typography texture.</td>
+  </tr>
+  <tr>
+    <td><strong><code>typography</code></strong></td>
+    <td>Scattered multi-layer composition. Design poster feel.</td>
+  </tr>
+  <tr>
+    <td><strong><code>flowfield</code></strong></td>
+    <td>Organic noise-driven flowing lines. Topographic texture.</td>
+  </tr>
+  <tr>
+    <td><strong><code>perspective</code></strong></td>
+    <td>Experimental ray simulation with obstacle physics.</td>
+  </tr>
+</table>
+
+> All procedural styles use **seeded randomness** — same workspace name always produces the same output. Deterministic and reproducible.
+
+<br />
 
 ## Multi-Zone Layouts
 
-A single wallpaper can contain multiple zones — split your desktop visually to match how you use it. Zones use flex proportions (like CSS flexbox) with configurable gaps and rounded corners.
+Split a single wallpaper into zones that mirror how you actually use the desktop. Flex proportions, rounded corners, configurable gaps.
 
-<!-- TODO: Add a screenshot of a multi-zone wallpaper, e.g., a 2:1 split
-     with "Code" on the left and "Browser" on the right. -->
+<!-- ┌─────────────────────────────────────────────────────────────────┐
+     │  MULTI-ZONE IMAGE                                              │
+     │                                                                │
+     │  Use your config with a 2:1 split space to generate this.     │
+     │  Show the wallpaper as it appears on a desktop — ideally      │
+     │  inside a macOS window chrome mockup.                          │
+     │                                                                │
+     │  Save as: docs/assets/multi-zone.png                           │
+     └─────────────────────────────────────────────────────────────────┘ -->
+
+<p align="center">
+  <img src="docs/assets/multi-zone.png" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width="700" />
+</p>
 
 ```json
 {
@@ -92,52 +179,53 @@ A single wallpaper can contain multiple zones — split your desktop visually to
 }
 ```
 
-## App Positioning
-
-With [Hammerspoon](https://www.hammerspoon.org/) installed, `wp apply` goes beyond wallpapers — it positions your apps into zones automatically. Define which apps go where in your config, and your entire workspace layout is applied in one command.
-
-```json
-{
-  "zones": [
-    {
-      "name": "Code",
-      "flex": 2,
-      "apps": ["Code", "Terminal"]
-    },
-    {
-      "name": "Reference",
-      "flex": 1,
-      "apps": ["Safari"]
-    }
-  ]
-}
-```
-
-```bash
-wp apply              # Apply wallpapers + position apps
-wp apply --apps       # Only reposition apps
-wp apply:undo         # Undo app positioning
-```
-
-Your workspace is now code. Version it, share it, reproduce it.
+<br />
 
 ## Workspace Navigation
 
-Navigate between spaces by name instead of swiping. The `goto` command supports a `cd -` style shortcut to jump back to where you were.
+Navigate by name, not by swiping. Supports `cd -` to jump back.
 
 ```bash
-wp goto code          # Switch to "Code" workspace
-wp goto               # Show picker
-wp goto -             # Jump back to previous workspace
+wp goto code       # Jump to "Code" workspace
+wp goto            # Show picker
+wp goto -          # Back to previous (like cd -)
 ```
 
-Workspaces are matched by ID, slug, or name (case-insensitive). If your workspace is named "Skydiving 🪂" with `"id": "skydiving"`, both `wp goto skydiving` and the full name work.
+> **Matching:** Workspaces are found by ID, slug, or name (case-insensitive).
+> A workspace named `"Skydiving 🪂"` with `"id": "skydiving"` matches `wp goto skydiving`.
+
+<br />
+
+## App Positioning
+
+With [Hammerspoon](https://www.hammerspoon.org/) installed, `wp apply` positions your apps into zones automatically. Your workspace layout becomes code — version it, share it, reproduce it.
+
+```bash
+wp apply              # Wallpapers + position apps
+wp apply --apps       # Only reposition apps
+wp apply:undo         # Undo positioning
+```
+
+<!-- ┌─────────────────────────────────────────────────────────────────┐
+     │  APP POSITIONING DEMO                                          │
+     │                                                                │
+     │  Screen recording (GIF or MP4→GIF) showing:                   │
+     │  1. Running `wp apply --all`                                   │
+     │  2. Wallpapers appearing on each space                        │
+     │  3. Apps sliding into position                                │
+     │                                                                │
+     │  Keep it short (5-8 seconds). Save as:                        │
+     │    docs/assets/apply-demo.gif                                  │
+     └─────────────────────────────────────────────────────────────────┘ -->
+
+<br />
 
 ## Config
 
-Create your config with `wp config:init`, then edit with `wp config:edit`.
+Create with `wp config:init`, edit with `wp config:edit`.
 
-**Simple format** — one zone per space:
+<details>
+<summary><b>Simple format</b> — one zone per space</summary>
 
 ```json
 {
@@ -155,7 +243,10 @@ Create your config with `wp config:init`, then edit with `wp config:edit`.
 }
 ```
 
-**Full format** — multi-zone spaces with app positioning:
+</details>
+
+<details>
+<summary><b>Full format</b> — multi-zone spaces with app positioning</summary>
 
 ```json
 {
@@ -192,22 +283,47 @@ Create your config with `wp config:init`, then edit with `wp config:edit`.
 }
 ```
 
-Config location: `~/.config/wallpapers/config.json`
+</details>
 
-The workspace order matches your macOS Spaces order (left to right). Both formats are supported — the legacy format is auto-converted internally.
+<details>
+<summary><b>Config reference</b></summary>
 
-**Workspace IDs:** Each workspace gets a filename-safe slug derived from its name (lowercase, spaces→hyphens, alphanumeric only). Use the `id` field to override, especially for names with emojis or special characters.
+| Field | Where | Description |
+|-------|-------|-------------|
+| `name` | zone | Display name on the wallpaper |
+| `description` | zone | Subtitle text below the name |
+| `bgColor` | zone / defaults | Background hex color (`#RRGGBB`) |
+| `textColor` | zone / defaults | Text hex color (`#RRGGBB`) |
+| `style` | zone / defaults | Visual style (see [Visual Styles](#visual-styles)) |
+| `id` | zone | Override filename slug (for emoji/special char names) |
+| `watermark` | zone | Enable center watermark (classic style) |
+| `borderText` | zone | Enable border text (classic style) |
+| `flex` | zone | Width proportion in multi-zone layouts |
+| `apps` | zone | Apps to position in this zone |
+| `gap` | space | Pixel gap between zones |
+| `cornerRadius` | space | Rounded corner radius for zones |
+| `chromeColor` | space | Background color visible in gaps |
+
+**Location:** `~/.config/wallpapers/config.json`
+
+**Workspace order** matches your macOS Spaces order (left to right).
+
+**IDs:** Auto-derived from name (lowercase, spaces→hyphens, alphanumeric only). Override with `id` for emoji or special character names.
+
+</details>
+
+<br />
 
 ## All Commands
 
 | Command | Description |
-|---------|-------------|
-| `wp` | Apply wallpapers + apps (shows picker, or use `--all`) |
+|:--------|:------------|
+| `wp` | Apply wallpapers + apps (picker, or `--all`) |
 | `wp quick` | Quick generate — just enter a name |
 | `wp goto [name]` | Switch workspace (picker if no name) |
 | `wp goto -` | Go back to previous workspace |
 | `wp generate` | Full interactive generator with all options |
-| `wp cli "Name" [options]` | Direct generation without prompts |
+| `wp cli "Name" [opts]` | Direct generation, no prompts |
 | `wp config:init` | Create starter config |
 | `wp config:edit` | Open config in editor |
 | `wp apply:undo` | Undo app positioning |
@@ -215,36 +331,34 @@ The workspace order matches your macOS Spaces order (left to right). Both format
 | `wp info:resolution` | Show screen resolution |
 | `wp info:list` | List generated wallpapers |
 | `wp info:wallpaper` | Show current wallpaper path |
-| `wp hammerspoon:config` | Generate Hammerspoon integration config |
 | `wp clean` | Delete all generated wallpapers |
-| `wp tutorial` | Interactive tutorial |
+| `wp tutorial` | Interactive walkthrough |
 
-## Scripting & CLI Reference
-
-For scripting or direct access, bypass the interactive prompts:
+<details>
+<summary><b>CLI flags reference</b></summary>
 
 ```bash
 swift run generate "Name" [options]
 ```
 
 | Flag | Description |
-|------|-------------|
+|:-----|:------------|
 | `-d, --description` | Subtitle text |
-| `-r, --resolution` | Preset: `1080p`, `1440p`, `4k`, `macbook-14`, `macbook-16`, `imac-24`, `studio-display` |
+| `-r, --resolution` | `1080p` · `1440p` · `4k` · `macbook-14` · `macbook-16` · `imac-24` · `studio-display` |
 | `--width, --height` | Custom dimensions |
-| `--bg-color` | Background hex color (`#RRGGBB`) |
-| `--text-color` | Text hex color (`#RRGGBB`) |
+| `--bg-color` | Background hex (`#RRGGBB`) |
+| `--text-color` | Text hex (`#RRGGBB`) |
+| `--style` | Visual style |
 | `--id` | Override filename slug |
 | `--index` | Space index number |
-| `--style` | Visual style (see [Visual Styles](#visual-styles)) |
-| `--watermark` | Enable center watermark (classic style) |
-| `--border-text` | Enable border text (classic style) |
-| `--watermark-opacity` | Watermark opacity (0.0–1.0) |
-| `--border-opacity` | Border text opacity (0.0–1.0) |
-| `--gradient-opacity` | Bottom gradient opacity (0.0–1.0) |
+| `--watermark` | Enable center watermark |
+| `--border-text` | Enable border text |
+| `--watermark-opacity` | `0.0`–`1.0` |
+| `--border-opacity` | `0.0`–`1.0` |
+| `--gradient-opacity` | `0.0`–`1.0` |
 | `-o, --output-dir` | Output directory |
 
-Resolution presets:
+**Resolution presets:**
 
 ```
 1080p: 1920×1080       macbook-14: 3024×1964
@@ -253,75 +367,131 @@ Resolution presets:
                        studio-display: 5120×2880
 ```
 
+</details>
+
+<br />
+
 ## Agent Integration
 
-This tool is designed to be used by both humans and AI agents. The `wp ai` command outputs structured context about the tool's capabilities, config format, and available commands — suitable for feeding into an LLM or agent system.
+[![Agent Ready](https://img.shields.io/badge/agent-ready-8A2BE2)](#agent-integration)
 
-If you're building an agent that manages workspaces, you can:
+Built to be used by humans and AI agents alike. All commands accept explicit arguments for non-interactive use.
 
-1. Read the config programmatically (`~/.config/wallpapers/config.json`)
-2. Generate wallpapers via the CLI (`wp cli "Name" --bg-color "#1a1a2e" --style diagonal`)
-3. Apply to spaces (`wp apply --all`)
-4. Navigate spaces (`wp goto <name>`)
+```bash
+# Read workspace definitions
+cat ~/.config/wallpapers/config.json
 
-All commands are non-interactive when given explicit arguments, making them safe for automated pipelines.
+# Generate programmatically
+wp cli "Code" --bg-color "#1a1a2e" --style diagonal --resolution macbook-14
 
-<!-- TODO: Add an example of an agent workflow — e.g., a script that reads a
-     project manifest and creates workspace configs automatically. -->
+# Apply to all spaces
+wp apply --all
+
+# Navigate
+wp goto code
+
+# Get agent context
+wp ai
+```
+
+> The `wp ai` command outputs structured context about capabilities, config format, and available commands — ready to feed into an LLM or agent pipeline.
+
+<br />
 
 ## Architecture
 
-**Swift library + bash orchestration.** The core rendering lives in `WallpaperKit` (pure Swift, Core Graphics, zero external dependencies). Bash tasks in `.mise/tasks/` handle user interaction, state management, and macOS integration via `osascript` and Hammerspoon.
-
 ```
-Sources/
-├── WallpaperKit/          # Core library — rendering, styles, layout
-│   ├── Generator.swift    # Wallpaper + multi-zone rendering
-│   ├── Style.swift        # Style enum
-│   ├── Styles/            # Style implementations (diagonal, flowfield, etc.)
-│   ├── Colors.swift       # Hex parsing, luminance, contrast
-│   ├── Noise.swift        # Seeded RNG + 2D noise for procedural styles
-│   └── ...
-├── generate/main.swift    # CLI: single wallpaper
-├── setup/main.swift       # CLI: batch generation from config
-└── playground/main.swift  # Experimental ray simulation sandbox
+┌─────────────────────────────────────────────────────┐
+│  bash tasks (.mise/tasks/)                          │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────────┐ │
+│  │apply │ │quick │ │goto  │ │config│ │ generate │ │
+│  └──┬───┘ └──┬───┘ └──┬───┘ └──────┘ └────┬─────┘ │
+│     │        │        │                    │       │
+│  ┌──▼────────▼────────▼────────────────────▼─────┐ │
+│  │           WallpaperKit (Swift)                 │ │
+│  │  ┌───────────┐ ┌────────┐ ┌────────────────┐  │ │
+│  │  │ Generator │ │ Styles │ │ Colors · Noise │  │ │
+│  │  └───────────┘ └────────┘ └────────────────┘  │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  Core Graphics · Core Text · ImageIO · AppKit       │
+│  Zero external dependencies                         │
+└─────────────────────────────────────────────────────┘
 ```
 
-Key design decisions:
-- **Deterministic output** — all procedural generation is seeded from workspace name
-- **No external dependencies** — only Apple frameworks (AppKit, Core Graphics, Core Text, ImageIO)
-- **Backward-compatible config** — legacy single-zone format auto-converts to the new multi-zone format
-- **Private APIs for space detection** — `CGSCopyManagedDisplaySpaces()` and `CGSGetActiveSpace()` are undocumented; may break in future macOS versions
+<details>
+<summary><b>Key design decisions</b></summary>
+
+- **Deterministic output** — all procedural generation is seeded from workspace name. Same name → same wallpaper.
+- **No external dependencies** — only Apple frameworks.
+- **Backward-compatible config** — legacy single-zone format auto-converts to multi-zone.
+- **Private APIs for space detection** — `CGSCopyManagedDisplaySpaces()` and `CGSGetActiveSpace()` are undocumented; may break in future macOS versions.
+- **Functional core, shell orchestration** — Swift library is pure and stateless. Bash tasks handle interaction, state, and OS integration.
+
+</details>
+
+<br />
 
 ## Roadmap
 
-Where this project could go next.
+> Where this is going. Contributions welcome.
 
-### Visual Styles
-- **More generative styles** — voronoi diagrams, gradient mesh, particle systems. The style system is a clean enum + render function; adding new styles is straightforward.
-- **Style parameters in config** — expose angles, opacities, densities, and noise scales as per-workspace config options for fine-grained customization.
-- **Theme system** — named color palettes (nord, dracula, solarized, catppuccin) that can be applied across all workspaces with a single setting.
+<table>
+  <tr>
+    <td width="50%" valign="top">
 
-### Workspace Templates
-- **Pre-built configs** for common workflows: developer (code + terminal + browser), designer (figma + preview + reference), writer (editor + research + notes).
-- **Shareable templates** — publish and install workspace configs like dotfiles. `wp template:install developer-dark`.
+**Workspace Templates**
+Pre-built configs for common workflows. Developer, designer, writer. Install like dotfiles.
+```bash
+wp template:install developer-dark
+```
 
-### Platform Support
-- **Multi-monitor** — per-display configs. The resolution system and multi-zone layout already handle arbitrary dimensions; per-display workspace definitions would be the next step.
-- **Linux / Wayland** — the rendering concepts (labeled wallpapers, workspace navigation) apply directly. Port the rendering to Cairo or Skia, use `swaymsg` / `wmctrl` for workspace switching.
-- **Windows** — Windows 10+ virtual desktops are accessible via the `IVirtualDesktopManager` COM interface. Wallpaper setting via `SystemParametersInfo` or registry. Rendering via Direct2D or cross-platform Skia backend. Space detection is actually better-documented than on macOS.
+**Theme System**
+Named palettes — nord, dracula, solarized, catppuccin — applied across all spaces with one setting.
 
-### App & Integration
-- **Menu bar app** — the Swift core is already a library (`WallpaperKit`). Wrapping it in a lightweight menu bar app would enable quick switching, regeneration, and preview without the terminal.
-- **Config hot-reload** — watch the config file with FSEvents and regenerate wallpapers on change. Edit your config, see the result instantly.
-- **Animated wallpapers** — the ray simulation already generates paths over time. Rendering to HEIC sequences or video for dynamic wallpapers is a short step from here.
+**More Styles**
+Voronoi, gradient mesh, particle systems. The style system is a clean `enum` + render function — adding styles is straightforward.
+
+</td>
+    <td width="50%" valign="top">
+
+**Menu Bar App**
+WallpaperKit is already a library. Wrap it in a native menu bar app for quick switching and preview.
+
+**Cross-Platform**
+Linux via Cairo + `swaymsg`/`wmctrl`. Windows via `IVirtualDesktopManager` COM + Direct2D. Space detection on Windows is actually better-documented than macOS.
+
+**Config Hot-Reload**
+Watch the config file, regenerate on change. Edit → see it instantly.
+
+  </td>
+  </tr>
+</table>
+
+<br />
 
 ## Requirements
 
-- macOS 13+
-- [mise](https://mise.jdx.dev/) (installs gum and other tools automatically)
-- [Hammerspoon](https://www.hammerspoon.org/) (optional, for app positioning and space navigation)
+| | |
+|:--|:--|
+| **macOS** | 13+ (Ventura or later) |
+| **mise** | [mise.jdx.dev](https://mise.jdx.dev/) — installs gum + other tools automatically |
+| **Hammerspoon** | [hammerspoon.org](https://www.hammerspoon.org/) — optional, for app positioning + navigation |
+
+<br />
+
+<div align="center">
 
 ## License
 
 MIT
+
+---
+
+<sub>
+macOS doesn't let you name your Spaces.
+<br />
+So we did it ourselves.
+</sub>
+
+</div>


### PR DESCRIPTION
The previous README undersold the project as a simple wallpaper labeler.
The new README presents it as a workspace identity system, covering visual
styles, multi-zone layouts, app positioning, agent integration, and a
roadmap for cross-platform support, templates, and a menu bar app.

Includes TODO placeholders for screenshots and visual examples.

https://claude.ai/code/session_01KBoE4ckWKVP3tg9Xtc26Ne