### PR TITLE
Add README.tsx, regenerate README from JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,422 @@
-# Wallpapers
+<div align="center">
 
 ```
          ▲ ▲
-        ╱   ╲
-       ╱ ° ° ╲      ╭───╮
-      ▕  ───  ▏ ◁━━━│ @ │━╮
-       ╲ ╰─╯ ╱      ╰───╯ │
-      ╱╱    ╲╲        ◀═══╯
-     ╱╱  ╱╲  ╲╲
-    ▔▔  ▔▔▔▔  ▔▔
-   ZERGLING    TURTLE
-               (in peril)
+        ╱ ● ●╲
+  ╔════╗╱     ╲╔════╗
+  ║ ◀══╝       ╚══▶ ║
+  ╚════╝╲     ╱╚════╝
+      ╲╲    ╱╱        ◀═══╯
+       ╲╲  ╱╲  ╱╱
+      ▔▔  ▔▔▔▔  ▔▔
 ```
 
-Generate labeled wallpapers for macOS workspaces.
+# Wallpapers
 
-**What's a workspace?** macOS lets you create multiple desktops called "Spaces" (swipe left/right with three fingers, or ctrl+←/→). But Apple doesn't let you name them - so this tool generates wallpapers with labels to identify each one.
+**A workspace identity system for macOS.**
+
+Generate labeled wallpapers. Navigate desktops by name. Position apps into zones.
+All from a single config file.
+
+[![Swift: 5.9+](https://img.shields.io/badge/Swift-5.9%2B-F05138?style=flat&logo=swift&logoColor=white)](https://swift.org)
+[![macOS: 13+](https://img.shields.io/badge/macOS-13%2B-000000?style=flat&logo=apple&logoColor=white)](https://www.apple.com/macos/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
+[![dependencies: 0](https://img.shields.io/badge/dependencies-0-brightgreen?style=flat)](Package.swift)
+[![agent: ready](https://img.shields.io/badge/agent-ready-8A2BE2?style=flat)](#agent-integration)
+
+</div>
+
+<p align="center">
+  <img src="docs/assets/hero.png" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width="800" />
+</p>
+
+<br />
+
+## Why?
+
+macOS lets you create multiple desktops — Apple calls them **Spaces**. You can swipe between them or use `ctrl+←/→`. But Apple doesn't let you name them. After three desktops they all look the same.
+
+This tool generates wallpapers with labels so you always know where you are. But it goes further: it's a full workspace-as-code system with navigation, app layout, and generative art.
+
+<br />
 
 ## Quick Start
 
 ```bash
-# Install mise (if you don't have it)
-curl https://mise.run | sh
+# Install
+git clone https://github.com/KnickKnackLabs/wallpapers.git ~/wallpapers
+cd ~/wallpapers && mise trust && mise install
 
-# Install wallpapers
-git clone https://github.com/KnickKnackLabs/wallpapers.git ~/.local/share/wallpapers
-cd ~/.local/share/wallpapers && mise trust && mise install
-
-# Add to your shell config (~/.zshrc or ~/.bashrc)
-eval "$(mise -C ~/.local/share/wallpapers run -q shell)"
-
-# Reload shell and run the tutorial
+# Shell setup
+echo 'eval "$(mise -C ~/wallpapers run -q shell)"' >> ~/.zshrc
 source ~/.zshrc
+
+# Go!
 wp tutorial
 ```
+
+<br />
 
 ## Usage
 
 ```bash
-wp                # Apply wallpaper (picker or --all)
+wp                # Apply wallpapers (picker or --all)
 wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
-wp goto -         # Go back to previous workspace
+wp goto -         # Go back (like cd -)
 ```
+
+<br />
+
+## Visual Styles
+
+Six built-in styles — from minimal to generative art. Set per-workspace in config or pick interactively with `wp generate`.
+
+<p align="center">
+  <img src="docs/assets/styles.png" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width="700" />
+</p>
+
+| Style | Description |
+| --- | --- |
+| **`classic`** | Clean and minimal. Optional watermark and border text. |
+| **`diagonal`** | 30° diagonal tiling — luxury fashion-brand aesthetic. |
+| **`tiled`** | Dense 75° wall-to-wall typography texture. |
+| **`typography`** | Scattered multi-layer composition. Design poster feel. |
+| **`flowfield`** | Organic noise-driven flowing lines. Topographic texture. |
+| **`perspective`** | Experimental ray simulation with obstacle physics. |
+
+> All procedural styles use **seeded randomness** — same workspace name always produces the same output. Deterministic and reproducible.
+
+<br />
+
+## Multi-Zone Layouts
+
+Split a single wallpaper into zones that mirror how you actually use the desktop. Flex proportions, rounded corners, configurable gaps.
+
+<p align="center">
+  <img src="docs/assets/multi-zone.png" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width="700" />
+</p>
+
+```json
+{
+  "spaces": [
+    {
+      "zones": [
+        { "name": "Code", "bgColor": "#1a1a2e", "style": "classic", "flex": 2 },
+        { "name": "Browser", "bgColor": "#0f3460", "style": "diagonal", "flex": 1 }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ]
+}
+```
+
+<br />
+
+## Workspace Navigation
+
+Navigate by name, not by swiping. Supports `cd -` to jump back.
+
+```bash
+wp goto code       # Jump to "Code" workspace
+wp goto            # Show picker
+wp goto -          # Back to previous (like cd -)
+```
+
+> **Matching:** Workspaces are found by ID, slug, or name (case-insensitive).
+> A workspace named `"Skydiving 🪂"` with `"id": "skydiving"` matches `wp goto skydiving`.
+
+<br />
+
+## App Positioning
+
+With [Hammerspoon](https://www.hammerspoon.org/) installed, `wp apply` positions your apps into zones automatically. Your workspace layout becomes code — version it, share it, reproduce it.
+
+```bash
+wp apply              # Wallpapers + position apps
+wp apply --apps       # Only reposition apps
+wp apply:undo         # Undo positioning
+```
+
+<br />
 
 ## Config
 
-Create your config with `wp config:init`, then edit with `wp config:edit`:
+Create with `wp config:init`, edit with `wp config:edit`.
+
+<details>
+<summary><b>Simple format — one zone per space</b></summary>
 
 ```json
 {
   "workspaces": [
     { "name": "Personal", "bgColor": "#2d3436" },
-    { "name": "Code", "bgColor": "#1a1a2e", "description": "Dev environment" },
-    { "name": "Design", "bgColor": "#0f3460" }
+    { "name": "Code", "bgColor": "#1a1a2e", "description": "Dev environment", "style": "diagonal" },
+    { "name": "Design", "bgColor": "#0f3460", "style": "typography" },
+    { "name": "Skydiving 🪂", "id": "skydiving", "bgColor": "#6c5ce7" }
   ],
   "defaults": {
     "bgColor": "#000000",
-    "textColor": "#ffffff"
+    "textColor": "#ffffff",
+    "style": "classic"
   }
 }
 ```
 
-The order of workspaces matches your Spaces order (left to right).
+</details>
 
-## Features
+<details>
+<summary><b>Full format — multi-zone spaces with app positioning</b></summary>
 
-- **Native Swift** - Core Graphics rendering, no external dependencies
-- **Auto-detect resolution** - Fits your screen perfectly
-- **LTR/RTL support** - Works with English, Hebrew, Arabic, etc.
-- **Space navigation** - Switch workspaces by name
+```json
+{
+  "spaces": [
+    {
+      "zones": [
+        {
+          "name": "Code",
+          "description": "Development",
+          "bgColor": "#1a1a2e",
+          "style": "classic",
+          "watermark": true,
+          "flex": 2,
+          "apps": ["Code"]
+        },
+        {
+          "name": "Docs",
+          "bgColor": "#0f3460",
+          "style": "diagonal",
+          "flex": 1,
+          "apps": ["Safari"]
+        }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ],
+  "defaults": {
+    "bgColor": "#000000",
+    "textColor": "#ffffff",
+    "style": "classic"
+  }
+}
+```
 
-## Requirements
+</details>
 
-- macOS 13+
-- [mise](https://mise.jdx.dev/) (installs other dependencies automatically)
+<details>
+<summary><b>Config reference</b></summary>
+
+| Field | Where | Description |
+| --- | --- | --- |
+| `name` | zone | Display name on the wallpaper |
+| `description` | zone | Subtitle text below the name |
+| `bgColor` | zone / defaults | Background hex color (`#RRGGBB`) |
+| `textColor` | zone / defaults | Text hex color (`#RRGGBB`) |
+| `style` | zone / defaults | Visual style (see [Visual Styles](#visual-styles)) |
+| `id` | zone | Override filename slug (for emoji/special char names) |
+| `watermark` | zone | Enable center watermark (classic style) |
+| `borderText` | zone | Enable border text (classic style) |
+| `flex` | zone | Width proportion in multi-zone layouts |
+| `apps` | zone | Apps to position in this zone |
+| `gap` | space | Pixel gap between zones |
+| `cornerRadius` | space | Rounded corner radius for zones |
+| `chromeColor` | space | Background color visible in gaps |
+
+**Location:** `~/.config/wallpapers/config.json`
+
+**Workspace order** matches your macOS Spaces order (left to right).
+
+**IDs:** Auto-derived from name (lowercase, spaces→hyphens, alphanumeric only). Override with `id` for emoji or special character names.
+
+</details>
+
+<br />
 
 ## All Commands
 
 | Command | Description |
-|---------|-------------|
-| `wp` | Apply wallpaper (shows picker, or use `--all`) |
-| `wp quick` | Quick generate - just enter a name |
+| --- | --- |
+| `wp` | Apply wallpapers + apps (picker, or `--all`) |
+| `wp quick` | Quick generate — just enter a name |
 | `wp goto [name]` | Switch workspace (picker if no name) |
 | `wp goto -` | Go back to previous workspace |
 | `wp generate` | Full interactive generator with all options |
+| `wp cli "Name" [opts]` | Direct generation, no prompts |
 | `wp config:init` | Create starter config |
 | `wp config:edit` | Open config in editor |
+| `wp apply:undo` | Undo app positioning |
 | `wp info:space` | Show current desktop number |
+| `wp info:resolution` | Show screen resolution |
 | `wp info:list` | List generated wallpapers |
+| `wp info:wallpaper` | Show current wallpaper path |
 | `wp clean` | Delete all generated wallpapers |
-| `wp tutorial` | Interactive tutorial |
+| `wp tutorial` | Interactive walkthrough |
 
-## Advanced
-
-For scripting or direct access:
+<details>
+<summary><b>CLI flags reference</b></summary>
 
 ```bash
-swift src/generate.swift "Name" [options]
-  -d, --description    Subtitle text
-  -r, --resolution     Preset: 1080p, 1440p, 4k, macbook-14, macbook-16, imac-24, studio-display
-  --width, --height    Custom dimensions
-  --bg-color           Background hex color
-  --text-color         Text hex color
+swift run generate "Name" [options]
 ```
+
+| Flag | Description |
+| --- | --- |
+| `-d, --description` | Subtitle text |
+| `-r, --resolution` | `1080p` · `1440p` · `4k` · `macbook-14` · `macbook-16` · `imac-24` · `studio-display` |
+| `--width, --height` | Custom dimensions |
+| `--bg-color` | Background hex (`#RRGGBB`) |
+| `--text-color` | Text hex (`#RRGGBB`) |
+| `--style` | Visual style |
+| `--id` | Override filename slug |
+| `--index` | Space index number |
+| `--watermark` | Enable center watermark |
+| `--border-text` | Enable border text |
+| `--watermark-opacity` | `0.0`–`1.0` |
+| `--border-opacity` | `0.0`–`1.0` |
+| `--gradient-opacity` | `0.0`–`1.0` |
+| `-o, --output-dir` | Output directory |
+
+**Resolution presets:**
+
+```
+1080p: 1920×1080       macbook-14: 3024×1964
+1440p: 2560×1440       macbook-16: 3456×2234
+4k:    3840×2160       imac-24:    4480×2520
+                       studio-display: 5120×2880
+```
+
+</details>
+
+<br />
+
+## Agent Integration
+
+[![agent: ready](https://img.shields.io/badge/agent-ready-8A2BE2?style=flat)](#agent-integration)
+
+Built to be used by humans and AI agents alike. All commands accept explicit arguments for non-interactive use.
+
+```bash
+# Read workspace definitions
+cat ~/.config/wallpapers/config.json
+
+# Generate programmatically
+wp cli "Code" --bg-color "#1a1a2e" --style diagonal --resolution macbook-14
+
+# Apply to all spaces
+wp apply --all
+
+# Navigate
+wp goto code
+
+# Get agent context
+wp ai
+```
+
+> The `wp ai` command outputs structured context about capabilities, config format, and available commands — ready to feed into an LLM or agent pipeline.
+
+<br />
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  bash tasks (.mise/tasks/)                          │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────────┐ │
+│  │apply │ │quick │ │goto  │ │config│ │ generate │ │
+│  └──┬───┘ └──┬───┘ └──┬───┘ └──────┘ └────┬─────┘ │
+│     │        │        │                    │       │
+│  ┌──▼────────▼────────▼────────────────────▼─────┐ │
+│  │           WallpaperKit (Swift)                 │ │
+│  │  ┌───────────┐ ┌────────┐ ┌────────────────┐  │ │
+│  │  │ Generator │ │ Styles │ │ Colors · Noise │  │ │
+│  │  └───────────┘ └────────┘ └────────────────┘  │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  Core Graphics · Core Text · ImageIO · AppKit       │
+│  Zero external dependencies                         │
+└─────────────────────────────────────────────────────┘
+```
+
+<details>
+<summary><b>Key design decisions</b></summary>
+
+- **Deterministic output** — all procedural generation is seeded from workspace name. Same name → same wallpaper.
+- **No external dependencies** — only Apple frameworks.
+- **Backward-compatible config** — legacy single-zone format auto-converts to multi-zone.
+- **Private APIs for space detection** — `CGSCopyManagedDisplaySpaces()` and `CGSGetActiveSpace()` are undocumented; may break in future macOS versions.
+- **Functional core, shell orchestration** — Swift library is pure and stateless. Bash tasks handle interaction, state, and OS integration.
+
+</details>
+
+<br />
+
+## Roadmap
+
+> Where this is going. Contributions welcome.
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+
+**Workspace Templates**
+Pre-built configs for common workflows. Developer, designer, writer. Install like dotfiles.
+
+```bash
+wp template:install developer-dark
+```
+
+**Theme System**
+Named palettes — nord, dracula, solarized, catppuccin — applied across all spaces with one setting.
+
+**More Styles**
+Voronoi, gradient mesh, particle systems. The style system is a clean `enum` + render function — adding styles is straightforward.
+
+
+</td>
+    <td width="50%" valign="top">
+
+**Menu Bar App**
+WallpaperKit is already a library. Wrap it in a native menu bar app for quick switching and preview.
+
+**Cross-Platform**
+Linux via Cairo + `swaymsg`/`wmctrl`. Windows via `IVirtualDesktopManager` COM + Direct2D. Space detection on Windows is actually better-documented than macOS.
+
+**Config Hot-Reload**
+Watch the config file, regenerate on change. Edit → see it instantly.
+
+
+</td>
+  </tr>
+</table>
+
+<br />
+
+## Requirements
+
+|   |   |
+| --- | --- |
+| **macOS** | 13+ (Ventura or later) |
+| **mise** | [mise.jdx.dev](https://mise.jdx.dev/) — installs gum + other tools automatically |
+| **Hammerspoon** | [hammerspoon.org](https://www.hammerspoon.org/) — optional, for app positioning + navigation |
+
+<br />
+
+<div align="center">
 
 ## License
 
 MIT
+
+---
+
+<sub>
+macOS doesn't let you name your Spaces.
+<br />
+So we did it ourselves.
+</sub></div>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All from a single config file.
 </div>
 
 <p align="center">
-  <img src="docs/assets/hero.png" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width="800" />
+  <img src="https://placehold.co/1400x400/2d3436/ffffff?text=Personal+%C2%B7+Code+%C2%B7+Design+%C2%B7+Music" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width="800" />
 </p>
 
 <br />
@@ -44,12 +44,7 @@ This tool generates wallpapers with labels so you always know where you are. But
 
 ```bash
 # Install
-git clone https://github.com/KnickKnackLabs/wallpapers.git ~/wallpapers
-cd ~/wallpapers && mise trust && mise install
-
-# Shell setup
-echo 'eval "$(mise -C ~/wallpapers run -q shell)"' >> ~/.zshrc
-source ~/.zshrc
+shiv install wallpapers --as wp
 
 # Go!
 wp tutorial
@@ -75,7 +70,7 @@ wp goto -         # Go back (like cd -)
 Six built-in styles — from minimal to generative art. Set per-workspace in config or pick interactively with `wp generate`.
 
 <p align="center">
-  <img src="docs/assets/styles.png" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width="700" />
+  <img src="https://placehold.co/1400x500/1a1a2e/ffffff?text=classic+%C2%B7+diagonal+%C2%B7+tiled+%C2%B7+typography+%C2%B7+flowfield+%C2%B7+perspective" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width="700" />
 </p>
 
 | Style | Description |
@@ -96,7 +91,7 @@ Six built-in styles — from minimal to generative art. Set per-workspace in con
 Split a single wallpaper into zones that mirror how you actually use the desktop. Flex proportions, rounded corners, configurable gaps.
 
 <p align="center">
-  <img src="docs/assets/multi-zone.png" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width="700" />
+  <img src="https://placehold.co/1400x400/0f3460/ffffff?text=Code+(2%2F3)+%7C+Browser+(1%2F3)" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width="700" />
 </p>
 
 ```json
@@ -419,4 +414,7 @@ MIT
 macOS doesn't let you name your Spaces.
 <br />
 So we did it ourselves.
+<br />
+<br />
+This README was created using [readme](https://github.com/KnickKnackLabs/readme).
 </sub></div>

--- a/README.md
+++ b/README.md
@@ -416,5 +416,5 @@ macOS doesn't let you name your Spaces.
 So we did it ourselves.
 <br />
 <br />
-This README was created using [readme](https://github.com/KnickKnackLabs/readme).
+This README was created using <a href="https://github.com/KnickKnackLabs/readme">readme</a>.
 </sub></div>

--- a/README.tsx
+++ b/README.tsx
@@ -119,8 +119,14 @@ const readme = (
       </Badges>
     </Center>
 
+    {/* TODO: Replace with real hero image (docs/assets/hero.png)
+         wp cli "Personal" --bg-color "#2d3436" --style classic
+         wp cli "Code" --bg-color "#1a1a2e" --style diagonal
+         wp cli "Design" --bg-color "#0f3460" --style typography
+         wp cli "Music" --bg-color "#6c5ce7" --style flowfield
+         Stitch into a single 1400×400 image with perspective tilt. */}
     <Align>
-      <Image src="docs/assets/hero.png" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width={800} />
+      <Image src="https://placehold.co/1400x400/2d3436/ffffff?text=Personal+%C2%B7+Code+%C2%B7+Design+%C2%B7+Music" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width={800} />
     </Align>
 
     <LineBreak />
@@ -142,12 +148,7 @@ const readme = (
 
     <Section title="Quick Start">
       <CodeBlock lang="bash">{`# Install
-git clone https://github.com/KnickKnackLabs/wallpapers.git ~/wallpapers
-cd ~/wallpapers && mise trust && mise install
-
-# Shell setup
-echo 'eval "$(mise -C ~/wallpapers run -q shell)"' >> ~/.zshrc
-source ~/.zshrc
+shiv install wallpapers --as wp
 
 # Go!
 wp tutorial`}</CodeBlock>
@@ -172,8 +173,13 @@ wp goto -         # Go back (like cd -)`}</CodeBlock>
         in config or pick interactively with <Code>wp generate</Code>.
       </Paragraph>
 
+      {/* TODO: Replace with real style grid (docs/assets/styles.png)
+           for s in classic diagonal tiled typography flowfield perspective; do
+             wp cli "Code" --bg-color "#1a1a2e" --style $s --resolution 1080p --id "style-$s"
+           done
+           Arrange as 3×2 grid, ~400×250 each. */}
       <Align>
-        <Image src="docs/assets/styles.png" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width={700} />
+        <Image src="https://placehold.co/1400x500/1a1a2e/ffffff?text=classic+%C2%B7+diagonal+%C2%B7+tiled+%C2%B7+typography+%C2%B7+flowfield+%C2%B7+perspective" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width={700} />
       </Align>
 
       <Table>
@@ -197,8 +203,10 @@ wp goto -         # Go back (like cd -)`}</CodeBlock>
         Flex proportions, rounded corners, configurable gaps.
       </Paragraph>
 
+      {/* TODO: Replace with real multi-zone image (docs/assets/multi-zone.png)
+           Use a 2:1 split config, show inside a macOS window chrome mockup. */}
       <Align>
-        <Image src="docs/assets/multi-zone.png" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width={700} />
+        <Image src="https://placehold.co/1400x400/0f3460/ffffff?text=Code+(2%2F3)+%7C+Browser+(1%2F3)" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width={700} />
       </Align>
 
       <CodeBlock lang="json">{`{
@@ -515,7 +523,10 @@ wp ai`}</CodeBlock>
       <Sub>
         macOS doesn't let you name your Spaces.{"\n"}
         <Raw>{"<br />"}</Raw>{"\n"}
-        So we did it ourselves.
+        So we did it ourselves.{"\n"}
+        <Raw>{"<br />"}</Raw>{"\n"}
+        <Raw>{"<br />"}</Raw>{"\n"}
+        This README was created using <Link href="https://github.com/KnickKnackLabs/readme">readme</Link>.
       </Sub>
     </Center>
   </>

--- a/README.tsx
+++ b/README.tsx
@@ -9,7 +9,7 @@ import {
   Badge, Badges, Center, Details, Section,
   Table, TableHead, TableRow, Cell,
   List, Item,
-  Raw, Sub, Align, HtmlTable, HtmlTr, HtmlTd,
+  Raw, HtmlLink, Sub, Align, HtmlTable, HtmlTr, HtmlTd,
 } from "readme/src/components";
 
 // --- Custom components ---
@@ -526,7 +526,7 @@ wp ai`}</CodeBlock>
         So we did it ourselves.{"\n"}
         <Raw>{"<br />"}</Raw>{"\n"}
         <Raw>{"<br />"}</Raw>{"\n"}
-        This README was created using <Link href="https://github.com/KnickKnackLabs/readme">readme</Link>.
+        This README was created using <HtmlLink href="https://github.com/KnickKnackLabs/readme">readme</HtmlLink>.
       </Sub>
     </Center>
   </>

--- a/README.tsx
+++ b/README.tsx
@@ -1,0 +1,524 @@
+// Bun's --tsconfig-override flag is broken (oven-sh/bun#22023), so when this
+// file lives outside the readme repo, auto-discovery won't find the right
+// tsconfig. The pragma below ensures our custom JSX runtime is used regardless.
+/** @jsxImportSource jsx-md */
+
+import {
+  Heading, Paragraph, CodeBlock, Blockquote, LineBreak, HR,
+  Bold, Code, Link, Image,
+  Badge, Badges, Center, Details, Section,
+  Table, TableHead, TableRow, Cell,
+  List, Item,
+  Raw, Sub, Align, HtmlTable, HtmlTr, HtmlTd,
+} from "readme/src/components";
+
+// --- Custom components ---
+
+function StyleRow({ name, desc }: { name: string; desc: string }) {
+  return (
+    <TableRow>
+      <Cell><Bold><Code>{name}</Code></Bold></Cell>
+      <Cell>{desc}</Cell>
+    </TableRow>
+  );
+}
+
+// --- Data ---
+
+const styles = [
+  { name: "classic", desc: "Clean and minimal. Optional watermark and border text." },
+  { name: "diagonal", desc: "30° diagonal tiling — luxury fashion-brand aesthetic." },
+  { name: "tiled", desc: "Dense 75° wall-to-wall typography texture." },
+  { name: "typography", desc: "Scattered multi-layer composition. Design poster feel." },
+  { name: "flowfield", desc: "Organic noise-driven flowing lines. Topographic texture." },
+  { name: "perspective", desc: "Experimental ray simulation with obstacle physics." },
+];
+
+const commands = [
+  { cmd: "wp", desc: "Apply wallpapers + apps (picker, or `--all`)" },
+  { cmd: "wp quick", desc: "Quick generate — just enter a name" },
+  { cmd: "wp goto [name]", desc: "Switch workspace (picker if no name)" },
+  { cmd: "wp goto -", desc: "Go back to previous workspace" },
+  { cmd: "wp generate", desc: "Full interactive generator with all options" },
+  { cmd: 'wp cli "Name" [opts]', desc: "Direct generation, no prompts" },
+  { cmd: "wp config:init", desc: "Create starter config" },
+  { cmd: "wp config:edit", desc: "Open config in editor" },
+  { cmd: "wp apply:undo", desc: "Undo app positioning" },
+  { cmd: "wp info:space", desc: "Show current desktop number" },
+  { cmd: "wp info:resolution", desc: "Show screen resolution" },
+  { cmd: "wp info:list", desc: "List generated wallpapers" },
+  { cmd: "wp info:wallpaper", desc: "Show current wallpaper path" },
+  { cmd: "wp clean", desc: "Delete all generated wallpapers" },
+  { cmd: "wp tutorial", desc: "Interactive walkthrough" },
+];
+
+const configFields = [
+  { field: "name", where: "zone", desc: "Display name on the wallpaper" },
+  { field: "description", where: "zone", desc: "Subtitle text below the name" },
+  { field: "bgColor", where: "zone / defaults", desc: "Background hex color (`#RRGGBB`)" },
+  { field: "textColor", where: "zone / defaults", desc: "Text hex color (`#RRGGBB`)" },
+  { field: "style", where: "zone / defaults", desc: "Visual style (see [Visual Styles](#visual-styles))" },
+  { field: "id", where: "zone", desc: "Override filename slug (for emoji/special char names)" },
+  { field: "watermark", where: "zone", desc: "Enable center watermark (classic style)" },
+  { field: "borderText", where: "zone", desc: "Enable border text (classic style)" },
+  { field: "flex", where: "zone", desc: "Width proportion in multi-zone layouts" },
+  { field: "apps", where: "zone", desc: "Apps to position in this zone" },
+  { field: "gap", where: "space", desc: "Pixel gap between zones" },
+  { field: "cornerRadius", where: "space", desc: "Rounded corner radius for zones" },
+  { field: "chromeColor", where: "space", desc: "Background color visible in gaps" },
+];
+
+const cliFlags = [
+  { flag: "-d, --description", desc: "Subtitle text" },
+  { flag: "-r, --resolution", desc: "`1080p` · `1440p` · `4k` · `macbook-14` · `macbook-16` · `imac-24` · `studio-display`" },
+  { flag: "--width, --height", desc: "Custom dimensions" },
+  { flag: "--bg-color", desc: "Background hex (`#RRGGBB`)" },
+  { flag: "--text-color", desc: "Text hex (`#RRGGBB`)" },
+  { flag: "--style", desc: "Visual style" },
+  { flag: "--id", desc: "Override filename slug" },
+  { flag: "--index", desc: "Space index number" },
+  { flag: "--watermark", desc: "Enable center watermark" },
+  { flag: "--border-text", desc: "Enable border text" },
+  { flag: "--watermark-opacity", desc: "`0.0`–`1.0`" },
+  { flag: "--border-opacity", desc: "`0.0`–`1.0`" },
+  { flag: "--gradient-opacity", desc: "`0.0`–`1.0`" },
+  { flag: "-o, --output-dir", desc: "Output directory" },
+];
+
+// --- README ---
+
+const readme = (
+  <>
+    <Center>
+      <CodeBlock>{`         ▲ ▲
+        ╱ ● ●╲
+  ╔════╗╱     ╲╔════╗
+  ║ ◀══╝       ╚══▶ ║
+  ╚════╝╲     ╱╚════╝
+      ╲╲    ╱╱        ◀═══╯
+       ╲╲  ╱╲  ╱╱
+      ▔▔  ▔▔▔▔  ▔▔`}</CodeBlock>
+
+      <Heading level={1}>Wallpapers</Heading>
+
+      <Paragraph>
+        <Bold>A workspace identity system for macOS.</Bold>
+      </Paragraph>
+
+      <Paragraph>
+        Generate labeled wallpapers. Navigate desktops by name. Position apps into zones.{"\n"}
+        All from a single config file.
+      </Paragraph>
+
+      <Badges>
+        <Badge label="Swift" value="5.9+" color="F05138" logo="swift" logoColor="white" href="https://swift.org" />
+        <Badge label="macOS" value="13+" color="000000" logo="apple" logoColor="white" href="https://www.apple.com/macos/" />
+        <Badge label="License" value="MIT" color="blue" href="LICENSE" />
+        <Badge label="dependencies" value="0" color="brightgreen" href="Package.swift" />
+        <Badge label="agent" value="ready" color="8A2BE2" href="#agent-integration" />
+      </Badges>
+    </Center>
+
+    <Align>
+      <Image src="docs/assets/hero.png" alt="Four wallpapers side by side: Personal (classic), Code (diagonal), Design (typography), Music (flowfield)" width={800} />
+    </Align>
+
+    <LineBreak />
+
+    <Section title="Why?">
+      <Paragraph>
+        macOS lets you create multiple desktops — Apple calls them <Bold>Spaces</Bold>.
+        You can swipe between them or use <Code>ctrl+←/→</Code>.
+        But Apple doesn't let you name them. After three desktops they all look the same.
+      </Paragraph>
+
+      <Paragraph>
+        This tool generates wallpapers with labels so you always know where you are.
+        But it goes further: it's a full workspace-as-code system with navigation, app layout, and generative art.
+      </Paragraph>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Quick Start">
+      <CodeBlock lang="bash">{`# Install
+git clone https://github.com/KnickKnackLabs/wallpapers.git ~/wallpapers
+cd ~/wallpapers && mise trust && mise install
+
+# Shell setup
+echo 'eval "$(mise -C ~/wallpapers run -q shell)"' >> ~/.zshrc
+source ~/.zshrc
+
+# Go!
+wp tutorial`}</CodeBlock>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Usage">
+      <CodeBlock lang="bash">{`wp                # Apply wallpapers (picker or --all)
+wp --all          # Apply wallpapers to all spaces from config
+wp quick          # Quick one-off wallpaper for current space
+wp goto           # Switch workspace (picker)
+wp goto code      # Switch to workspace by name
+wp goto -         # Go back (like cd -)`}</CodeBlock>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Visual Styles">
+      <Paragraph>
+        Six built-in styles — from minimal to generative art. Set per-workspace
+        in config or pick interactively with <Code>wp generate</Code>.
+      </Paragraph>
+
+      <Align>
+        <Image src="docs/assets/styles.png" alt="Grid showing all six visual styles: classic, diagonal, tiled, typography, flowfield, perspective" width={700} />
+      </Align>
+
+      <Table>
+        <TableHead>
+          <Cell>Style</Cell>
+          <Cell>Description</Cell>
+        </TableHead>
+        {styles.map(s => <StyleRow name={s.name} desc={s.desc} />)}
+      </Table>
+
+      <Blockquote>
+        All procedural styles use <Bold>seeded randomness</Bold> — same workspace name always produces the same output. Deterministic and reproducible.
+      </Blockquote>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Multi-Zone Layouts">
+      <Paragraph>
+        Split a single wallpaper into zones that mirror how you actually use the desktop.
+        Flex proportions, rounded corners, configurable gaps.
+      </Paragraph>
+
+      <Align>
+        <Image src="docs/assets/multi-zone.png" alt="A wallpaper split into two zones: Code (2/3 width, dark blue) and Browser (1/3 width, navy)" width={700} />
+      </Align>
+
+      <CodeBlock lang="json">{`{
+  "spaces": [
+    {
+      "zones": [
+        { "name": "Code", "bgColor": "#1a1a2e", "style": "classic", "flex": 2 },
+        { "name": "Browser", "bgColor": "#0f3460", "style": "diagonal", "flex": 1 }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ]
+}`}</CodeBlock>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Workspace Navigation">
+      <Paragraph>
+        Navigate by name, not by swiping. Supports <Code>cd -</Code> to jump back.
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`wp goto code       # Jump to "Code" workspace
+wp goto            # Show picker
+wp goto -          # Back to previous (like cd -)`}</CodeBlock>
+
+      <Blockquote>
+        <Bold>Matching:</Bold> Workspaces are found by ID, slug, or name (case-insensitive).{"\n"}
+        A workspace named <Code>{'"Skydiving 🪂"'}</Code> with <Code>{'"id": "skydiving"'}</Code> matches <Code>wp goto skydiving</Code>.
+      </Blockquote>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="App Positioning">
+      <Paragraph>
+        With <Link href="https://www.hammerspoon.org/">Hammerspoon</Link> installed,{" "}
+        <Code>wp apply</Code> positions your apps into zones automatically. Your workspace
+        layout becomes code — version it, share it, reproduce it.
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`wp apply              # Wallpapers + position apps
+wp apply --apps       # Only reposition apps
+wp apply:undo         # Undo positioning`}</CodeBlock>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Config">
+      <Paragraph>
+        Create with <Code>wp config:init</Code>, edit with <Code>wp config:edit</Code>.
+      </Paragraph>
+
+      <Details summary="Simple format — one zone per space">
+        <CodeBlock lang="json">{`{
+  "workspaces": [
+    { "name": "Personal", "bgColor": "#2d3436" },
+    { "name": "Code", "bgColor": "#1a1a2e", "description": "Dev environment", "style": "diagonal" },
+    { "name": "Design", "bgColor": "#0f3460", "style": "typography" },
+    { "name": "Skydiving 🪂", "id": "skydiving", "bgColor": "#6c5ce7" }
+  ],
+  "defaults": {
+    "bgColor": "#000000",
+    "textColor": "#ffffff",
+    "style": "classic"
+  }
+}`}</CodeBlock>
+      </Details>
+
+      <Details summary="Full format — multi-zone spaces with app positioning">
+        <CodeBlock lang="json">{`{
+  "spaces": [
+    {
+      "zones": [
+        {
+          "name": "Code",
+          "description": "Development",
+          "bgColor": "#1a1a2e",
+          "style": "classic",
+          "watermark": true,
+          "flex": 2,
+          "apps": ["Code"]
+        },
+        {
+          "name": "Docs",
+          "bgColor": "#0f3460",
+          "style": "diagonal",
+          "flex": 1,
+          "apps": ["Safari"]
+        }
+      ],
+      "gap": 8,
+      "cornerRadius": 10,
+      "chromeColor": "#000000"
+    }
+  ],
+  "defaults": {
+    "bgColor": "#000000",
+    "textColor": "#ffffff",
+    "style": "classic"
+  }
+}`}</CodeBlock>
+      </Details>
+
+      <Details summary="Config reference">
+        <Table>
+          <TableHead>
+            <Cell>Field</Cell>
+            <Cell>Where</Cell>
+            <Cell>Description</Cell>
+          </TableHead>
+          {configFields.map(f => (
+            <TableRow>
+              <Cell><Code>{f.field}</Code></Cell>
+              <Cell>{f.where}</Cell>
+              <Cell>{f.desc}</Cell>
+            </TableRow>
+          ))}
+        </Table>
+
+        <Paragraph>
+          <Bold>Location:</Bold> <Code>~/.config/wallpapers/config.json</Code>
+        </Paragraph>
+
+        <Paragraph>
+          <Bold>Workspace order</Bold> matches your macOS Spaces order (left to right).
+        </Paragraph>
+
+        <Paragraph>
+          <Bold>IDs:</Bold> Auto-derived from name (lowercase, spaces→hyphens, alphanumeric only).
+          Override with <Code>id</Code> for emoji or special character names.
+        </Paragraph>
+      </Details>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="All Commands">
+      <Table>
+        <TableHead>
+          <Cell>Command</Cell>
+          <Cell>Description</Cell>
+        </TableHead>
+        {commands.map(c => (
+          <TableRow>
+            <Cell><Code>{c.cmd}</Code></Cell>
+            <Cell>{c.desc}</Cell>
+          </TableRow>
+        ))}
+      </Table>
+
+      <Details summary="CLI flags reference">
+        <CodeBlock lang="bash">{`swift run generate "Name" [options]`}</CodeBlock>
+
+        <Table>
+          <TableHead>
+            <Cell>Flag</Cell>
+            <Cell>Description</Cell>
+          </TableHead>
+          {cliFlags.map(f => (
+            <TableRow>
+              <Cell><Code>{f.flag}</Code></Cell>
+              <Cell>{f.desc}</Cell>
+            </TableRow>
+          ))}
+        </Table>
+
+        <Paragraph><Bold>Resolution presets:</Bold></Paragraph>
+
+        <CodeBlock>{`1080p: 1920×1080       macbook-14: 3024×1964
+1440p: 2560×1440       macbook-16: 3456×2234
+4k:    3840×2160       imac-24:    4480×2520
+                       studio-display: 5120×2880`}</CodeBlock>
+      </Details>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Agent Integration">
+      <Badges>
+        <Badge label="agent" value="ready" color="8A2BE2" href="#agent-integration" />
+      </Badges>
+
+      <Paragraph>
+        Built to be used by humans and AI agents alike. All commands accept explicit arguments for non-interactive use.
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`# Read workspace definitions
+cat ~/.config/wallpapers/config.json
+
+# Generate programmatically
+wp cli "Code" --bg-color "#1a1a2e" --style diagonal --resolution macbook-14
+
+# Apply to all spaces
+wp apply --all
+
+# Navigate
+wp goto code
+
+# Get agent context
+wp ai`}</CodeBlock>
+
+      <Blockquote>
+        The <Code>wp ai</Code> command outputs structured context about capabilities,
+        config format, and available commands — ready to feed into an LLM or agent pipeline.
+      </Blockquote>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Architecture">
+      <CodeBlock>{`┌─────────────────────────────────────────────────────┐
+│  bash tasks (.mise/tasks/)                          │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────────┐ │
+│  │apply │ │quick │ │goto  │ │config│ │ generate │ │
+│  └──┬───┘ └──┬───┘ └──┬───┘ └──────┘ └────┬─────┘ │
+│     │        │        │                    │       │
+│  ┌──▼────────▼────────▼────────────────────▼─────┐ │
+│  │           WallpaperKit (Swift)                 │ │
+│  │  ┌───────────┐ ┌────────┐ ┌────────────────┐  │ │
+│  │  │ Generator │ │ Styles │ │ Colors · Noise │  │ │
+│  │  └───────────┘ └────────┘ └────────────────┘  │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  Core Graphics · Core Text · ImageIO · AppKit       │
+│  Zero external dependencies                         │
+└─────────────────────────────────────────────────────┘`}</CodeBlock>
+
+      <Details summary="Key design decisions">
+        <List>
+          <Item><Bold>Deterministic output</Bold> — all procedural generation is seeded from workspace name. Same name → same wallpaper.</Item>
+          <Item><Bold>No external dependencies</Bold> — only Apple frameworks.</Item>
+          <Item><Bold>Backward-compatible config</Bold> — legacy single-zone format auto-converts to multi-zone.</Item>
+          <Item><Bold>Private APIs for space detection</Bold> — <Code>CGSCopyManagedDisplaySpaces()</Code> and <Code>CGSGetActiveSpace()</Code> are undocumented; may break in future macOS versions.</Item>
+          <Item><Bold>Functional core, shell orchestration</Bold> — Swift library is pure and stateless. Bash tasks handle interaction, state, and OS integration.</Item>
+        </List>
+      </Details>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Roadmap">
+      <Blockquote>Where this is going. Contributions welcome.</Blockquote>
+
+      <HtmlTable>
+        <HtmlTr>
+          <HtmlTd width="50%" valign="top">
+            <Paragraph>
+              <Bold>Workspace Templates</Bold>{"\n"}
+              Pre-built configs for common workflows. Developer, designer, writer. Install like dotfiles.
+            </Paragraph>
+            <CodeBlock lang="bash">{`wp template:install developer-dark`}</CodeBlock>
+            <Paragraph>
+              <Bold>Theme System</Bold>{"\n"}
+              Named palettes — nord, dracula, solarized, catppuccin — applied across all spaces with one setting.
+            </Paragraph>
+            <Paragraph>
+              <Bold>More Styles</Bold>{"\n"}
+              Voronoi, gradient mesh, particle systems. The style system is a clean <Code>enum</Code> + render function — adding styles is straightforward.
+            </Paragraph>
+          </HtmlTd>
+          <HtmlTd width="50%" valign="top">
+            <Paragraph>
+              <Bold>Menu Bar App</Bold>{"\n"}
+              WallpaperKit is already a library. Wrap it in a native menu bar app for quick switching and preview.
+            </Paragraph>
+            <Paragraph>
+              <Bold>Cross-Platform</Bold>{"\n"}
+              {"Linux via Cairo + `swaymsg`/`wmctrl`. Windows via `IVirtualDesktopManager` COM + Direct2D. Space detection on Windows is actually better-documented than macOS."}
+            </Paragraph>
+            <Paragraph>
+              <Bold>Config Hot-Reload</Bold>{"\n"}
+              Watch the config file, regenerate on change. Edit → see it instantly.
+            </Paragraph>
+          </HtmlTd>
+        </HtmlTr>
+      </HtmlTable>
+    </Section>
+
+    <LineBreak />
+
+    <Section title="Requirements">
+      <Table>
+        <TableHead>
+          <Cell>{" "}</Cell>
+          <Cell>{" "}</Cell>
+        </TableHead>
+        <TableRow>
+          <Cell><Bold>macOS</Bold></Cell>
+          <Cell>13+ (Ventura or later)</Cell>
+        </TableRow>
+        <TableRow>
+          <Cell><Bold>mise</Bold></Cell>
+          <Cell><Link href="https://mise.jdx.dev/">mise.jdx.dev</Link> — installs gum + other tools automatically</Cell>
+        </TableRow>
+        <TableRow>
+          <Cell><Bold>Hammerspoon</Bold></Cell>
+          <Cell><Link href="https://www.hammerspoon.org/">hammerspoon.org</Link> — optional, for app positioning + navigation</Cell>
+        </TableRow>
+      </Table>
+    </Section>
+
+    <LineBreak />
+
+    <Center>
+      <Section title="License">
+        <Paragraph>MIT</Paragraph>
+      </Section>
+
+      <HR />
+
+      <Sub>
+        macOS doesn't let you name your Spaces.{"\n"}
+        <Raw>{"<br />"}</Raw>{"\n"}
+        So we did it ourselves.
+      </Sub>
+    </Center>
+  </>
+);
+
+console.log(readme);


### PR DESCRIPTION
## Summary

- Port the README to a JSX source file using [KnickKnackLabs/readme](https://github.com/KnickKnackLabs/readme)
- README.tsx composes components (`Heading`, `Table`, `Badge`, `Details`, etc.) and renders to markdown via `readme build`
- Includes the `@jsxImportSource` pragma for cross-repo builds (workaround for [oven-sh/bun#22023](https://github.com/oven-sh/bun/issues/22023))
- README.md is the generated output — edit README.tsx, not README.md

## Test plan

- [x] `readme build` produces clean markdown from wallpapers repo
- [x] Output matches previous README content (expanded with full docs)
- [x] Cross-repo build works with pragma + tsconfig override

🤖 Generated with [Claude Code](https://claude.com/claude-code)