### PR TITLE
feat: snapshot spaces into TSX recipes

### DIFF
--- a/.mise/tasks/snapshot
+++ b/.mise/tasks/snapshot
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#MISE description="Snapshot current macOS Spaces into a starter WALLPAPERS.tsx"
+#USAGE flag "--out <out>" help="TSX output file (default: WALLPAPERS.tsx in caller directory)"
+#USAGE flag "--json" help="Print normalized snapshot JSON instead of writing TSX"
+#USAGE flag "--force" help="Overwrite an existing TSX output file"
+#USAGE flag "--include-windows" help="Include current windows in JSON and TSX comments"
+#USAGE example "wp snapshot" header="Create ./WALLPAPERS.tsx from current Spaces"
+#USAGE example "wp snapshot --force --out recipes/current.tsx" header="Overwrite an explicit output path"
+#USAGE example "wp snapshot --json --include-windows" header="Inspect normalized Spaces and windows"
+set -euo pipefail
+
+source "${MISE_CONFIG_ROOT}/lib/common.sh"
+
+if [ "${usage_json:-false}" = "true" ] && { [ -n "${usage_out:-}" ] || [ "${usage_force:-false}" = "true" ]; }; then
+  echo "error: --json cannot be combined with --out or --force" >&2
+  exit 2
+fi
+
+butthair_cmd="${BUTTHAIR:-butthair}"
+if ! command -v "$butthair_cmd" >/dev/null 2>&1; then
+  echo "error: butthair not found. Install with: shiv install butthair" >&2
+  exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+spaces_json="$tmp_dir/spaces.json"
+if ! "$butthair_cmd" spaces:list --json > "$spaces_json"; then
+  echo "error: could not read spaces from butthair" >&2
+  exit 1
+fi
+
+args=("--spaces" "$spaces_json")
+
+if [ "${usage_include_windows:-false}" = "true" ]; then
+  windows_json="$tmp_dir/windows.json"
+  if ! "$butthair_cmd" windows:list --json > "$windows_json"; then
+    echo "error: could not read windows from butthair" >&2
+    exit 1
+  fi
+  args+=("--windows" "$windows_json")
+fi
+
+if [ "${usage_json:-false}" = "true" ]; then
+  args+=("--json")
+else
+  if [ -n "${usage_out:-}" ]; then
+    out_path=$(wallpapers_resolve_path "$usage_out")
+  else
+    out_path=$(wallpapers_resolve_path "WALLPAPERS.tsx")
+  fi
+
+  if [ -e "$out_path" ] && [ "${usage_force:-false}" != "true" ]; then
+    echo "error: output already exists: $out_path" >&2
+    echo "rerun with --force to overwrite" >&2
+    exit 1
+  fi
+
+  printf 'out:    %s\n' "$out_path"
+  args+=("--out" "$out_path")
+fi
+
+NODE_PATH="${MISE_CONFIG_ROOT}/tsx-runtime" \
+  bun "${MISE_CONFIG_ROOT}/tsx-runtime/snapshot.ts" "${args[@]}"

--- a/.mise/tasks/snapshot
+++ b/.mise/tasks/snapshot
@@ -11,7 +11,46 @@ set -euo pipefail
 
 source "${MISE_CONFIG_ROOT}/lib/common.sh"
 
-if [ "${usage_json:-false}" = "true" ] && { [ -n "${usage_out:-}" ] || [ "${usage_force:-false}" = "true" ]; }; then
+snapshot_json=false
+snapshot_force=false
+snapshot_include_windows=false
+snapshot_out=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      snapshot_json=true
+      ;;
+    --force)
+      snapshot_force=true
+      ;;
+    --include-windows)
+      snapshot_include_windows=true
+      ;;
+    --out)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: --out requires a value" >&2
+        exit 2
+      fi
+      snapshot_out="$1"
+      ;;
+    --out=*)
+      snapshot_out="${1#--out=}"
+      ;;
+    -h|--help)
+      echo "Usage: wp snapshot [--json] [--out <out>] [--force] [--include-windows]" >&2
+      exit 2
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ "$snapshot_json" = "true" ] && { [ -n "$snapshot_out" ] || [ "$snapshot_force" = "true" ]; }; then
   echo "error: --json cannot be combined with --out or --force" >&2
   exit 2
 fi
@@ -33,7 +72,7 @@ fi
 
 args=("--spaces" "$spaces_json")
 
-if [ "${usage_include_windows:-false}" = "true" ]; then
+if [ "$snapshot_include_windows" = "true" ]; then
   windows_json="$tmp_dir/windows.json"
   if ! "$butthair_cmd" windows:list --json > "$windows_json"; then
     echo "error: could not read windows from butthair" >&2
@@ -42,16 +81,16 @@ if [ "${usage_include_windows:-false}" = "true" ]; then
   args+=("--windows" "$windows_json")
 fi
 
-if [ "${usage_json:-false}" = "true" ]; then
+if [ "$snapshot_json" = "true" ]; then
   args+=("--json")
 else
-  if [ -n "${usage_out:-}" ]; then
-    out_path=$(wallpapers_resolve_path "$usage_out")
+  if [ -n "$snapshot_out" ]; then
+    out_path=$(wallpapers_resolve_path "$snapshot_out")
   else
     out_path=$(wallpapers_resolve_path "WALLPAPERS.tsx")
   fi
 
-  if [ -e "$out_path" ] && [ "${usage_force:-false}" != "true" ]; then
+  if [ -e "$out_path" ] && [ "$snapshot_force" != "true" ]; then
     echo "error: output already exists: $out_path" >&2
     echo "rerun with --force to overwrite" >&2
     exit 1

--- a/.mise/tasks/tutorial/apply
+++ b/.mise/tasks/tutorial/apply
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Apply wallpaper to spaces demo"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/.mise/tasks/tutorial/config
+++ b/.mise/tasks/tutorial/config
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Configuration setup walkthrough"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/.mise/tasks/tutorial/generate
+++ b/.mise/tasks/tutorial/generate
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Wallpaper generation demo"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/.mise/tasks/tutorial/intro
+++ b/.mise/tasks/tutorial/intro
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Introduction and overview"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/.mise/tasks/tutorial/navigate
+++ b/.mise/tasks/tutorial/navigate
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Workspace navigation demo"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/.mise/tasks/tutorial/summary
+++ b/.mise/tasks/tutorial/summary
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Tutorial: Command reference and completion"
+#MISE hide=true
 set -e
 
 # Check dependencies

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This tool generates wallpapers with labels so you can tell them apart.
 ![lang: Swift + Bash](https://img.shields.io/badge/lang-Swift%20%2B%20Bash-F05138?style=flat&logo=swift&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![tasks: 22](https://img.shields.io/badge/tasks-22-blue?style=flat)
-![tests: 26](https://img.shields.io/badge/tests-26-green?style=flat)
+![tests: 27](https://img.shields.io/badge/tests-27-green?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -97,35 +97,35 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 
 | Task | Description |
 | --- | --- |
+| `ai` | Agent instructions for helping users |
 | `apply` | Apply workspace config (wallpapers, apps, or both) |
 | `apply:undo` | Close windows created by the last 'apply --apps' |
+| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
+| `clean` | Remove all generated wallpapers |
+| `cli` | Run generator directly with arguments |
+| `config:edit` | Edit config file in your editor |
+| `config:init` | Initialize config file with example workspaces |
+| `generate` | Generate a wallpaper interactively |
+| `goto` | Switch to a workspace by name |
+| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
+| `help` | Show generator CLI help |
+| `info:list` | List generated wallpapers |
+| `info:resolution` | Show your screen resolution |
+| `info:space` | Show current desktop space |
+| `info:wallpaper` | Show current wallpaper file path |
+| `open` | Open the wallpapers directory in Finder |
+| `quick` | Quick generate with just a name (auto-detects screen resolution) |
+| `readme` | Regenerate README.md from README.tsx |
+| `shell` | Output shell configuration (use with eval) |
 | `snapshot` | Snapshot current macOS Spaces into a starter WALLPAPERS.tsx |
 | `tutorial` | Interactive tutorial to learn the wallpaper generator |
-| `goto` | Switch to a workspace by name |
-| `config:init` | Initialize config file with example workspaces |
-| `config:edit` | Edit config file in your editor |
-| `shell` | Output shell configuration (use with eval) |
-| `quick` | Quick generate with just a name (auto-detects screen resolution) |
-| `cli` | Run generator directly with arguments |
-| `readme` | Regenerate README.md from README.tsx |
-| `info:resolution` | Show your screen resolution |
-| `info:list` | List generated wallpapers |
-| `info:wallpaper` | Show current wallpaper file path |
-| `info:space` | Show current desktop space |
-| `clean` | Remove all generated wallpapers |
-| `ai` | Agent instructions for helping users |
-| `generate` | Generate a wallpaper interactively |
-| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
-| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
-| `open` | Open the wallpapers directory in Finder |
-| `help` | Show generator CLI help |
 
 ## Development
 
 ```bash
 gh repo clone KnickKnackLabs/wallpapers
 cd wallpapers && mise trust && mise install
-mise run test   # 26 tests
+mise run test   # 27 tests
 ```
 
 **Architecture:** Swift layer (`Sources/WallpaperKit/`) handles Core Graphics rendering. Bash tasks in `.mise/tasks/` handle user interaction via `gum`. Shared helpers live in `lib/common.sh`. Space management delegates to [butthair](https://github.com/KnickKnackLabs/butthair).

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This tool generates wallpapers with labels so you can tell them apart.
 
 ![lang: Swift + Bash](https://img.shields.io/badge/lang-Swift%20%2B%20Bash-F05138?style=flat&logo=swift&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tasks: 25](https://img.shields.io/badge/tasks-25-blue?style=flat)
-![tests: 18](https://img.shields.io/badge/tests-18-green?style=flat)
+![tasks: 22](https://img.shields.io/badge/tasks-22-blue?style=flat)
+![tests: 26](https://img.shields.io/badge/tests-26-green?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -49,6 +49,7 @@ wp tutorial
 wp                # Apply wallpaper (picker or --all)
 wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
+wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
 wp apply --config ./WALLPAPERS.json --wallpapers
 wp goto           # Switch workspace (picker)
@@ -76,7 +77,7 @@ Create your config with `wp config init`, then edit with `wp config edit`:
 
 The order of workspaces matches your Spaces order (left to right).
 
-For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`.
+For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. To start from your current macOS layout, run `wp snapshot`; it writes one starter zone per Space, with optional window comments via `wp snapshot --include-windows`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`.
 
 ## Resolution presets
 
@@ -96,13 +97,10 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 
 | Task | Description |
 | --- | --- |
+| `apply` | Apply workspace config (wallpapers, apps, or both) |
 | `apply:undo` | Close windows created by the last 'apply --apps' |
-| `tutorial:apply` | Tutorial: Apply wallpaper to spaces demo |
-| `tutorial:navigate` | Tutorial: Workspace navigation demo |
-| `tutorial:intro` | Tutorial: Introduction and overview |
-| `tutorial:config` | Tutorial: Configuration setup walkthrough |
-| `tutorial:generate` | Tutorial: Wallpaper generation demo |
-| `tutorial:summary` | Tutorial: Command reference and completion |
+| `snapshot` | Snapshot current macOS Spaces into a starter WALLPAPERS.tsx |
+| `tutorial` | Interactive tutorial to learn the wallpaper generator |
 | `goto` | Switch to a workspace by name |
 | `config:init` | Initialize config file with example workspaces |
 | `config:edit` | Edit config file in your editor |
@@ -127,7 +125,7 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 ```bash
 gh repo clone KnickKnackLabs/wallpapers
 cd wallpapers && mise trust && mise install
-mise run test   # 18 tests
+mise run test   # 26 tests
 ```
 
 **Architecture:** Swift layer (`Sources/WallpaperKit/`) handles Core Graphics rendering. Bash tasks in `.mise/tasks/` handle user interaction via `gum`. Shared helpers live in `lib/common.sh`. Space management delegates to [butthair](https://github.com/KnickKnackLabs/butthair).

--- a/README.tsx
+++ b/README.tsx
@@ -46,7 +46,7 @@ function collectTasks(dir: string, prefix = ""): TaskInfo[] {
 }
 
 const taskDir = join(REPO_DIR, ".mise/tasks");
-const taskInfo = collectTasks(taskDir);
+const taskInfo = collectTasks(taskDir).sort((a, b) => a.name.localeCompare(b.name));
 const tasks = taskInfo.map((task) => task.name);
 
 // Count tests from .bats files

--- a/README.tsx
+++ b/README.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource jsx-md */
 
-import { readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join, resolve } from "path";
 
 import {
@@ -14,32 +14,40 @@ import {
 
 const REPO_DIR = resolve(import.meta.dirname);
 
-// Count tasks (excluding _ helpers and test)
-function countTasks(dir: string, prefix = ""): string[] {
-  const tasks: string[] = [];
+type TaskInfo = { name: string; filePath: string; desc: string };
+
+function hiddenTask(filePath: string): boolean {
+  return readFileSync(filePath, "utf-8").includes("#MISE hide=true");
+}
+
+function taskDescription(filePath: string): string {
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/#MISE description="(.+?)"/);
+  return match?.[1] ?? "";
+}
+
+// Count public tasks, including namespace _default entrypoints and excluding hidden helpers.
+function collectTasks(dir: string, prefix = ""): TaskInfo[] {
+  const tasks: TaskInfo[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith("_")) continue;
     if (entry.name === "test") continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      tasks.push(...countTasks(full, `${prefix}${entry.name}:`));
-    } else {
-      tasks.push(`${prefix}${entry.name}`);
+      const defaultTask = join(full, "_default");
+      if (existsSync(defaultTask) && !hiddenTask(defaultTask)) {
+        tasks.push({ name: `${prefix}${entry.name}`, filePath: defaultTask, desc: taskDescription(defaultTask) });
+      }
+      tasks.push(...collectTasks(full, `${prefix}${entry.name}:`));
+    } else if (!entry.name.startsWith("_") && !hiddenTask(full)) {
+      tasks.push({ name: `${prefix}${entry.name}`, filePath: full, desc: taskDescription(full) });
     }
   }
   return tasks;
 }
 
 const taskDir = join(REPO_DIR, ".mise/tasks");
-const tasks = countTasks(taskDir);
-
-// Parse task descriptions
-const taskInfo = tasks.map((name) => {
-  const filePath = join(taskDir, name.replace(/:/g, "/"));
-  const content = readFileSync(filePath, "utf-8");
-  const match = content.match(/#MISE description="(.+?)"/);
-  return { name, desc: match?.[1] ?? "" };
-});
+const taskInfo = collectTasks(taskDir);
+const tasks = taskInfo.map((task) => task.name);
 
 // Count tests from .bats files
 const testDir = join(REPO_DIR, "test");
@@ -112,6 +120,7 @@ wp tutorial`}</CodeBlock>
       <CodeBlock lang="bash">{`wp                # Apply wallpaper (picker or --all)
 wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
+wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
 wp apply --config ./WALLPAPERS.json --wallpapers
 wp goto           # Switch workspace (picker)
@@ -143,8 +152,11 @@ wp goto -         # Go back to previous workspace`}</CodeBlock>
 
       <Paragraph>
         For repo-owned recipes, write <Code>WALLPAPERS.tsx</Code>, then run{" "}
-        <Code>wp build</Code>. The generated <Code>WALLPAPERS.json</Code> can be applied{" "}
-        explicitly with <Code>wp apply --config ./WALLPAPERS.json --wallpapers</Code>.
+        <Code>wp build</Code>. To start from your current macOS layout, run{" "}
+        <Code>wp snapshot</Code>; it writes one starter zone per Space, with optional window
+        comments via <Code>wp snapshot --include-windows</Code>. The generated{" "}
+        <Code>WALLPAPERS.json</Code> can be applied explicitly with{" "}
+        <Code>wp apply --config ./WALLPAPERS.json --wallpapers</Code>.
       </Paragraph>
     </Section>
 

--- a/test/snapshot.bats
+++ b/test/snapshot.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+  CALLER_PWD="$BATS_TEST_TMPDIR/workspace"
+  export CALLER_PWD
+  mkdir -p "$CALLER_PWD"
+  setup_mock_butthair
+}
+
+setup_mock_butthair() {
+  MOCK_SPACES_JSON="$BATS_TEST_TMPDIR/spaces.json"
+  MOCK_WINDOWS_JSON="$BATS_TEST_TMPDIR/windows.json"
+  export MOCK_SPACES_JSON MOCK_WINDOWS_JSON
+
+  cat > "$MOCK_SPACES_JSON" <<'JSON'
+[
+  { "id": 3, "active": false, "type": "user", "index": 1 },
+  { "id": 712, "active": true, "type": "user", "index": 2 }
+]
+JSON
+
+  cat > "$MOCK_WINDOWS_JSON" <<'JSON'
+[
+  { "spaces": [2], "app": "Obsidian", "title": "New tab - home", "visible": true, "id": 95481 },
+  { "spaces": [2], "app": "Ghostty", "title": "π - fold", "visible": true, "id": 25033 },
+  { "spaces": [1], "app": "Firefox", "title": "Roundcube Webmail", "visible": false, "id": 87120 }
+]
+JSON
+
+  BUTTHAIR="$BATS_TEST_TMPDIR/butthair"
+  export BUTTHAIR
+  cat > "$BUTTHAIR" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  "spaces:list")
+    cat "${MOCK_SPACES_JSON:?}"
+    ;;
+  "windows:list")
+    cat "${MOCK_WINDOWS_JSON:?}"
+    ;;
+  *)
+    echo "unexpected butthair call: $*" >&2
+    exit 99
+    ;;
+esac
+BASH
+  chmod +x "$BUTTHAIR"
+}
+
+@test "snapshot writes WALLPAPERS.tsx in caller directory" {
+  run wallpapers snapshot
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"out:    $CALLER_PWD/WALLPAPERS.tsx"* ]]
+  [[ "$output" == *"wrote $CALLER_PWD/WALLPAPERS.tsx"* ]]
+  [ -f "$CALLER_PWD/WALLPAPERS.tsx" ]
+
+  run grep -F "macOS space #2, id=712, type=user, active" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -eq 0 ]
+
+  run wallpapers build
+
+  [ "$status" -eq 0 ]
+  run jq -r '.spaces | length' "$CALLER_PWD/WALLPAPERS.json"
+  [ "$output" = "2" ]
+  run jq -r '.spaces[1].zones[0].name' "$CALLER_PWD/WALLPAPERS.json"
+  [ "$output" = "space-2" ]
+}
+
+@test "snapshot --json emits normalized snapshot without writing TSX" {
+  run wallpapers snapshot --json
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$CALLER_PWD/WALLPAPERS.tsx" ]
+
+  snapshot_json="$output"
+  run jq -r '.snapshotVersion' <<< "$snapshot_json"
+  [ "$output" = "1" ]
+  run jq -r '.spaces[1].active' <<< "$snapshot_json"
+  [ "$output" = "true" ]
+  run jq -r '.spaces[0].id' <<< "$snapshot_json"
+  [ "$output" = "3" ]
+}
+
+@test "snapshot refuses to overwrite unless --force is passed" {
+  echo "existing" > "$CALLER_PWD/WALLPAPERS.tsx"
+
+  run wallpapers snapshot
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"output already exists"* ]]
+  [ "$(cat "$CALLER_PWD/WALLPAPERS.tsx")" = "existing" ]
+
+  run wallpapers snapshot --force
+
+  [ "$status" -eq 0 ]
+  run grep -F "<WorkspaceSet" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -eq 0 ]
+}
+
+@test "snapshot accepts an explicit output path relative to caller" {
+  run wallpapers snapshot --out recipes/current.tsx
+
+  [ "$status" -eq 0 ]
+  [ -f "$CALLER_PWD/recipes/current.tsx" ]
+  [ ! -e "$CALLER_PWD/WALLPAPERS.tsx" ]
+}
+
+@test "snapshot --include-windows includes window data in comments and JSON" {
+  run wallpapers snapshot --include-windows
+
+  [ "$status" -eq 0 ]
+  run grep -F "Obsidian — New tab - home" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -eq 0 ]
+  run grep -F "Firefox — Roundcube Webmail (hidden)" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -eq 0 ]
+
+  run wallpapers build
+  [ "$status" -eq 0 ]
+
+  rm "$CALLER_PWD/WALLPAPERS.tsx"
+  run wallpapers snapshot --json --include-windows
+
+  [ "$status" -eq 0 ]
+  snapshot_json="$output"
+  run jq -r '.spaces[1].windows | length' <<< "$snapshot_json"
+  [ "$output" = "2" ]
+  run jq -r '.spaces[1].windows[0].app' <<< "$snapshot_json"
+  [ "$output" = "Ghostty" ]
+}
+
+@test "snapshot --json rejects output flags" {
+  run wallpapers snapshot --json --out current.tsx
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--json cannot be combined"* ]]
+}

--- a/test/snapshot.bats
+++ b/test/snapshot.bats
@@ -131,6 +131,17 @@ BASH
   [ "$output" = "Ghostty" ]
 }
 
+
+@test "snapshot ignores inherited usage variables from parent mise sessions" {
+  usage_json=true usage_out=stale.tsx usage_force=true usage_include_windows=true run wallpapers snapshot
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"out:    $CALLER_PWD/WALLPAPERS.tsx"* ]]
+  [ -f "$CALLER_PWD/WALLPAPERS.tsx" ]
+  run grep -F "windows:" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -ne 0 ]
+}
+
 @test "snapshot --json rejects output flags" {
   run wallpapers snapshot --json --out current.tsx
 

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+}
+
+@test "mise tasks shows the tutorial entrypoint but hides tutorial modules" {
+  run mise -C "$REPO_ROOT" tasks
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tutorial"* ]]
+  [[ "$output" != *"tutorial:intro"* ]]
+  [[ "$output" != *"tutorial:config"* ]]
+  [[ "$output" != *"tutorial:generate"* ]]
+  [[ "$output" != *"tutorial:apply"* ]]
+  [[ "$output" != *"tutorial:navigate"* ]]
+  [[ "$output" != *"tutorial:summary"* ]]
+}
+
+@test "hidden tutorial modules remain visible with --hidden" {
+  run mise -C "$REPO_ROOT" tasks --hidden
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tutorial:intro"* ]]
+  [[ "$output" == *"tutorial:summary"* ]]
+}

--- a/tsx-runtime/snapshot.ts
+++ b/tsx-runtime/snapshot.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+
+type SpaceSnapshot = {
+  index: number;
+  id?: number | string;
+  active: boolean;
+  type?: string;
+  windows?: WindowSnapshot[];
+};
+
+type WindowSnapshot = {
+  id?: number | string;
+  app: string;
+  title: string;
+  visible?: boolean;
+  spaces: number[];
+};
+
+type Options = {
+  spaces?: string;
+  windows?: string;
+  out?: string;
+  json: boolean;
+};
+
+function usage(): never {
+  console.error("Usage: snapshot.ts --spaces <spaces.json> [--windows <windows.json>] [--out <WALLPAPERS.tsx> | --json]");
+  process.exit(2);
+}
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = { json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--spaces":
+        i += 1;
+        if (i >= argv.length) usage();
+        options.spaces = argv[i];
+        break;
+      case "--windows":
+        i += 1;
+        if (i >= argv.length) usage();
+        options.windows = argv[i];
+        break;
+      case "--out":
+        i += 1;
+        if (i >= argv.length) usage();
+        options.out = argv[i];
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "-h":
+      case "--help":
+        usage();
+        break;
+      default:
+        console.error(`Unknown argument: ${arg}`);
+        usage();
+    }
+  }
+
+  if (!options.spaces) usage();
+  if (options.json === Boolean(options.out)) usage();
+  return options;
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function asObject(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a number`);
+  }
+  return value;
+}
+
+function asOptionalId(value: unknown): number | string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.length > 0) return value;
+  return undefined;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseSpaces(raw: unknown): SpaceSnapshot[] {
+  if (!Array.isArray(raw)) {
+    throw new Error("spaces snapshot must be an array");
+  }
+
+  const spaces = raw.map((item, position) => {
+    const space = asObject(item, `spaces[${position}]`);
+    const index = space.index === undefined ? position + 1 : asNumber(space.index, `spaces[${position}].index`);
+    return {
+      index,
+      id: asOptionalId(space.id),
+      active: space.active === true,
+      type: asOptionalString(space.type),
+    };
+  });
+
+  if (spaces.length === 0) {
+    throw new Error("spaces snapshot is empty");
+  }
+
+  return spaces.sort((a, b) => a.index - b.index);
+}
+
+function parseWindows(raw: unknown): WindowSnapshot[] {
+  if (!Array.isArray(raw)) {
+    throw new Error("windows snapshot must be an array");
+  }
+
+  return raw.flatMap((item, position) => {
+    const win = asObject(item, `windows[${position}]`);
+    const spacesRaw = win.spaces;
+    if (!Array.isArray(spacesRaw)) return [];
+    const spaces = spacesRaw.filter((space): space is number => typeof space === "number" && Number.isFinite(space));
+    if (spaces.length === 0) return [];
+
+    return [{
+      id: asOptionalId(win.id),
+      app: asOptionalString(win.app) ?? "Unknown app",
+      title: asOptionalString(win.title) ?? "Untitled",
+      visible: typeof win.visible === "boolean" ? win.visible : undefined,
+      spaces,
+    }];
+  });
+}
+
+function attachWindows(spaces: SpaceSnapshot[], windows: WindowSnapshot[]): SpaceSnapshot[] {
+  return spaces.map((space) => ({
+    ...space,
+    windows: windows
+      .filter((win) => win.spaces.includes(space.index))
+      .sort((a, b) => `${a.app}\u0000${a.title}`.localeCompare(`${b.app}\u0000${b.title}`)),
+  }));
+}
+
+function commentText(value: string): string {
+  return value.replace(/\*\//g, "* /").replace(/[\r\n]+/g, " ");
+}
+
+function spaceComment(space: SpaceSnapshot): string {
+  const parts = [`macOS space #${space.index}`];
+  if (space.id !== undefined) parts.push(`id=${space.id}`);
+  if (space.type) parts.push(`type=${space.type}`);
+  if (space.active) parts.push("active");
+  return parts.join(", ");
+}
+
+function renderTsx(spaces: SpaceSnapshot[]): string {
+  const lines = [
+    'import { WorkspaceSet, Space, Zone } from "wallpapers";',
+    "",
+    "export default (",
+    '  <WorkspaceSet defaults={{ bgColor: "#000000", textColor: "#ffffff", gap: 4 }}>',
+  ];
+
+  for (const space of spaces) {
+    lines.push(`    {/* ${commentText(spaceComment(space))} */}`);
+    if (space.windows && space.windows.length > 0) {
+      lines.push("    {/* windows:");
+      for (const win of space.windows) {
+        const visible = win.visible === false ? " (hidden)" : "";
+        lines.push(`      - ${commentText(`${win.app} — ${win.title}${visible}`)}`);
+      }
+      lines.push("    */}");
+    }
+    lines.push("    <Space>");
+    lines.push(`      <Zone name="space-${space.index}" description="TODO" />`);
+    lines.push("    </Space>");
+    lines.push("");
+  }
+
+  lines.push("  </WorkspaceSet>");
+  lines.push(");");
+  lines.push("");
+  return lines.join("\n");
+}
+
+const options = parseArgs(process.argv.slice(2));
+const spacesPath = resolve(options.spaces!);
+const windowsPath = options.windows ? resolve(options.windows) : undefined;
+
+let spaces = parseSpaces(readJson(spacesPath));
+if (windowsPath) {
+  spaces = attachWindows(spaces, parseWindows(readJson(windowsPath)));
+}
+
+const snapshot = {
+  snapshotVersion: 1,
+  generatedBy: {
+    tool: "wallpapers",
+    command: "snapshot",
+  },
+  spaces,
+};
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+} else {
+  const out = resolve(options.out!);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, renderTsx(spaces));
+  console.log(`wrote ${out}`);
+}


### PR DESCRIPTION
## Summary

- add `wp snapshot` to bootstrap a starter `WALLPAPERS.tsx` from current macOS Spaces via `butthair`
- support `--json`, `--out`, `--force`, and `--include-windows` for comments/diagnostics
- hide tutorial module subtasks so only `wp tutorial` is public
- update README task discovery to include namespace `_default` entrypoints and skip hidden tasks

Refs #50.

## Verification

- `mise run test` (26/26)
- `swift test` (5/5)
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`
- `bash -n .mise/tasks/snapshot .mise/tasks/tutorial/{apply,config,generate,intro,navigate,summary} test/snapshot.bats test/tasks.bats`
- `shellcheck -x .mise/tasks/snapshot`
- actual `wp snapshot --include-windows` smoke against Or's current Spaces into a temp dir, then `wp build` (3 spaces)
- `mise run readme && git diff --exit-code README.md`
