### PR TITLE
fix: sort generated task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,28 +97,28 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 
 | Task | Description |
 | --- | --- |
+| `ai` | Agent instructions for helping users |
 | `apply` | Apply workspace config (wallpapers, apps, or both) |
 | `apply:undo` | Close windows created by the last 'apply --apps' |
+| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
+| `clean` | Remove all generated wallpapers |
+| `cli` | Run generator directly with arguments |
+| `config:edit` | Edit config file in your editor |
+| `config:init` | Initialize config file with example workspaces |
+| `generate` | Generate a wallpaper interactively |
+| `goto` | Switch to a workspace by name |
+| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
+| `help` | Show generator CLI help |
+| `info:list` | List generated wallpapers |
+| `info:resolution` | Show your screen resolution |
+| `info:space` | Show current desktop space |
+| `info:wallpaper` | Show current wallpaper file path |
+| `open` | Open the wallpapers directory in Finder |
+| `quick` | Quick generate with just a name (auto-detects screen resolution) |
+| `readme` | Regenerate README.md from README.tsx |
+| `shell` | Output shell configuration (use with eval) |
 | `snapshot` | Snapshot current macOS Spaces into a starter WALLPAPERS.tsx |
 | `tutorial` | Interactive tutorial to learn the wallpaper generator |
-| `goto` | Switch to a workspace by name |
-| `config:init` | Initialize config file with example workspaces |
-| `config:edit` | Edit config file in your editor |
-| `shell` | Output shell configuration (use with eval) |
-| `quick` | Quick generate with just a name (auto-detects screen resolution) |
-| `cli` | Run generator directly with arguments |
-| `readme` | Regenerate README.md from README.tsx |
-| `info:resolution` | Show your screen resolution |
-| `info:list` | List generated wallpapers |
-| `info:wallpaper` | Show current wallpaper file path |
-| `info:space` | Show current desktop space |
-| `clean` | Remove all generated wallpapers |
-| `ai` | Agent instructions for helping users |
-| `generate` | Generate a wallpaper interactively |
-| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
-| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
-| `open` | Open the wallpapers directory in Finder |
-| `help` | Show generator CLI help |
 
 ## Development
 

--- a/README.tsx
+++ b/README.tsx
@@ -29,7 +29,7 @@ function taskDescription(filePath: string): string {
 // Count public tasks, including namespace _default entrypoints and excluding hidden helpers.
 function collectTasks(dir: string, prefix = ""): TaskInfo[] {
   const tasks: TaskInfo[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
     if (entry.name === "test") continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {


### PR DESCRIPTION
Fix-it for #52.

README.tsx now sorts task directory entries before collecting them, and README.md is regenerated from that deterministic order. On this Linux runner, `mise run readme && git diff --exit-code README.md` currently rewrites the task table because `readdirSync()` order differs from the committed macOS order.