### PR TITLE
fix: ignore inherited snapshot usage vars

### DIFF
--- a/.mise/tasks/snapshot
+++ b/.mise/tasks/snapshot
@@ -11,7 +11,46 @@ set -euo pipefail
 
 source "${MISE_CONFIG_ROOT}/lib/common.sh"
 
-if [ "${usage_json:-false}" = "true" ] && { [ -n "${usage_out:-}" ] || [ "${usage_force:-false}" = "true" ]; }; then
+snapshot_json=false
+snapshot_force=false
+snapshot_include_windows=false
+snapshot_out=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      snapshot_json=true
+      ;;
+    --force)
+      snapshot_force=true
+      ;;
+    --include-windows)
+      snapshot_include_windows=true
+      ;;
+    --out)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: --out requires a value" >&2
+        exit 2
+      fi
+      snapshot_out="$1"
+      ;;
+    --out=*)
+      snapshot_out="${1#--out=}"
+      ;;
+    -h|--help)
+      echo "Usage: wp snapshot [--json] [--out <out>] [--force] [--include-windows]" >&2
+      exit 2
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ "$snapshot_json" = "true" ] && { [ -n "$snapshot_out" ] || [ "$snapshot_force" = "true" ]; }; then
   echo "error: --json cannot be combined with --out or --force" >&2
   exit 2
 fi
@@ -33,7 +72,7 @@ fi
 
 args=("--spaces" "$spaces_json")
 
-if [ "${usage_include_windows:-false}" = "true" ]; then
+if [ "$snapshot_include_windows" = "true" ]; then
   windows_json="$tmp_dir/windows.json"
   if ! "$butthair_cmd" windows:list --json > "$windows_json"; then
     echo "error: could not read windows from butthair" >&2
@@ -42,16 +81,16 @@ if [ "${usage_include_windows:-false}" = "true" ]; then
   args+=("--windows" "$windows_json")
 fi
 
-if [ "${usage_json:-false}" = "true" ]; then
+if [ "$snapshot_json" = "true" ]; then
   args+=("--json")
 else
-  if [ -n "${usage_out:-}" ]; then
-    out_path=$(wallpapers_resolve_path "$usage_out")
+  if [ -n "$snapshot_out" ]; then
+    out_path=$(wallpapers_resolve_path "$snapshot_out")
   else
     out_path=$(wallpapers_resolve_path "WALLPAPERS.tsx")
   fi
 
-  if [ -e "$out_path" ] && [ "${usage_force:-false}" != "true" ]; then
+  if [ -e "$out_path" ] && [ "$snapshot_force" != "true" ]; then
     echo "error: output already exists: $out_path" >&2
     echo "rerun with --force to overwrite" >&2
     exit 1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This tool generates wallpapers with labels so you can tell them apart.
 ![lang: Swift + Bash](https://img.shields.io/badge/lang-Swift%20%2B%20Bash-F05138?style=flat&logo=swift&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![tasks: 22](https://img.shields.io/badge/tasks-22-blue?style=flat)
-![tests: 26](https://img.shields.io/badge/tests-26-green?style=flat)
+![tests: 27](https://img.shields.io/badge/tests-27-green?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -97,35 +97,35 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 
 | Task | Description |
 | --- | --- |
+| `ai` | Agent instructions for helping users |
 | `apply` | Apply workspace config (wallpapers, apps, or both) |
 | `apply:undo` | Close windows created by the last 'apply --apps' |
+| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
+| `clean` | Remove all generated wallpapers |
+| `cli` | Run generator directly with arguments |
+| `config:edit` | Edit config file in your editor |
+| `config:init` | Initialize config file with example workspaces |
+| `generate` | Generate a wallpaper interactively |
+| `goto` | Switch to a workspace by name |
+| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
+| `help` | Show generator CLI help |
+| `info:list` | List generated wallpapers |
+| `info:resolution` | Show your screen resolution |
+| `info:space` | Show current desktop space |
+| `info:wallpaper` | Show current wallpaper file path |
+| `open` | Open the wallpapers directory in Finder |
+| `quick` | Quick generate with just a name (auto-detects screen resolution) |
+| `readme` | Regenerate README.md from README.tsx |
+| `shell` | Output shell configuration (use with eval) |
 | `snapshot` | Snapshot current macOS Spaces into a starter WALLPAPERS.tsx |
 | `tutorial` | Interactive tutorial to learn the wallpaper generator |
-| `goto` | Switch to a workspace by name |
-| `config:init` | Initialize config file with example workspaces |
-| `config:edit` | Edit config file in your editor |
-| `shell` | Output shell configuration (use with eval) |
-| `quick` | Quick generate with just a name (auto-detects screen resolution) |
-| `cli` | Run generator directly with arguments |
-| `readme` | Regenerate README.md from README.tsx |
-| `info:resolution` | Show your screen resolution |
-| `info:list` | List generated wallpapers |
-| `info:wallpaper` | Show current wallpaper file path |
-| `info:space` | Show current desktop space |
-| `clean` | Remove all generated wallpapers |
-| `ai` | Agent instructions for helping users |
-| `generate` | Generate a wallpaper interactively |
-| `build` | Build WALLPAPERS.tsx into a versioned JSON config |
-| `hammerspoon:config` | Install wp workspace integration into Hammerspoon config |
-| `open` | Open the wallpapers directory in Finder |
-| `help` | Show generator CLI help |
 
 ## Development
 
 ```bash
 gh repo clone KnickKnackLabs/wallpapers
 cd wallpapers && mise trust && mise install
-mise run test   # 26 tests
+mise run test   # 27 tests
 ```
 
 **Architecture:** Swift layer (`Sources/WallpaperKit/`) handles Core Graphics rendering. Bash tasks in `.mise/tasks/` handle user interaction via `gum`. Shared helpers live in `lib/common.sh`. Space management delegates to [butthair](https://github.com/KnickKnackLabs/butthair).

--- a/README.tsx
+++ b/README.tsx
@@ -46,7 +46,7 @@ function collectTasks(dir: string, prefix = ""): TaskInfo[] {
 }
 
 const taskDir = join(REPO_DIR, ".mise/tasks");
-const taskInfo = collectTasks(taskDir);
+const taskInfo = collectTasks(taskDir).sort((a, b) => a.name.localeCompare(b.name));
 const tasks = taskInfo.map((task) => task.name);
 
 // Count tests from .bats files

--- a/test/snapshot.bats
+++ b/test/snapshot.bats
@@ -131,6 +131,17 @@ BASH
   [ "$output" = "Ghostty" ]
 }
 
+
+@test "snapshot ignores inherited usage variables from parent mise sessions" {
+  usage_json=true usage_out=stale.tsx usage_force=true usage_include_windows=true run wallpapers snapshot
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"out:    $CALLER_PWD/WALLPAPERS.tsx"* ]]
+  [ -f "$CALLER_PWD/WALLPAPERS.tsx" ]
+  run grep -F "windows:" "$CALLER_PWD/WALLPAPERS.tsx"
+  [ "$status" -ne 0 ]
+}
+
 @test "snapshot --json rejects output flags" {
   run wallpapers snapshot --json --out current.tsx
 


### PR DESCRIPTION
## Summary

- parse `wp snapshot` flags from argv instead of inherited `usage_*` env vars
- add regression coverage for parent mise-session leakage
- sort README task rows deterministically and regenerate README

## Verification

- `mise run test`
- `bash -n .mise/tasks/snapshot test/snapshot.bats`
- `shellcheck -x .mise/tasks/snapshot`
- `codebase lint:mise-settings "$PWD"`
- `git diff --check`
