### PR TITLE
feat: forward build args to TSX recipes

### DIFF
--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -3,17 +3,66 @@
 #USAGE flag "--source <source>" help="TSX source file (default: WALLPAPERS.tsx in caller directory)"
 #USAGE flag "--out <out>" help="JSON output file (default: WALLPAPERS.json next to source)"
 #USAGE flag "--check" help="Fail if the output file is missing or out of date"
+#USAGE arg "[args]" var=#true help="Arguments to pass to WALLPAPERS.tsx"
 #USAGE example "wp build" header="Build ./WALLPAPERS.tsx to ./WALLPAPERS.json"
 #USAGE example "wp build --source recipes/agents.tsx --out .wallpapers/agents.json" header="Build explicit paths"
+#USAGE example "wp build --set quick" header="Pass arguments through to WALLPAPERS.tsx"
 set -euo pipefail
 
 source "${MISE_CONFIG_ROOT}/lib/common.sh"
 
-caller_dir=$(wallpapers_caller_dir)
-source_path=$(wallpapers_resolve_path "${usage_source:-WALLPAPERS.tsx}")
+build_source="WALLPAPERS.tsx"
+build_out=""
+build_check=false
+recipe_args=()
 
-if [ -n "${usage_out:-}" ]; then
-  out_path=$(wallpapers_resolve_path "$usage_out")
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: --source requires a value" >&2
+        exit 2
+      fi
+      build_source="$1"
+      ;;
+    --source=*)
+      build_source="${1#--source=}"
+      ;;
+    --out)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: --out requires a value" >&2
+        exit 2
+      fi
+      build_out="$1"
+      ;;
+    --out=*)
+      build_out="${1#--out=}"
+      ;;
+    --check)
+      build_check=true
+      ;;
+    --)
+      shift
+      while [ "$#" -gt 0 ]; do
+        recipe_args+=("$1")
+        shift
+      done
+      break
+      ;;
+    *)
+      recipe_args+=("$1")
+      ;;
+  esac
+  shift
+done
+
+caller_dir=$(wallpapers_caller_dir)
+source_path=$(wallpapers_resolve_path "$build_source")
+
+if [ -n "$build_out" ]; then
+  out_path=$(wallpapers_resolve_path "$build_out")
 else
   out_path="${source_path%.*}.json"
 fi
@@ -27,8 +76,11 @@ printf 'source: %s\n' "$source_path"
 printf 'out:    %s\n' "$out_path"
 
 args=("--source" "$source_path" "--out" "$out_path")
-if [ "${usage_check:-false}" = "true" ]; then
+if [ "$build_check" = "true" ]; then
   args+=("--check")
+fi
+if [ "${#recipe_args[@]}" -gt 0 ]; then
+  args+=("--" "${recipe_args[@]}")
 fi
 
 (

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This tool generates wallpapers with labels so you can tell them apart.
 ![lang: Swift + Bash](https://img.shields.io/badge/lang-Swift%20%2B%20Bash-F05138?style=flat&logo=swift&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![tasks: 22](https://img.shields.io/badge/tasks-22-blue?style=flat)
-![tests: 27](https://img.shields.io/badge/tests-27-green?style=flat)
+![tests: 29](https://img.shields.io/badge/tests-29-green?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -51,6 +51,7 @@ wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
 wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
+wp build --set quick  # Pass arguments to WALLPAPERS.tsx
 wp apply --config ./WALLPAPERS.json --wallpapers
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
@@ -77,7 +78,7 @@ Create your config with `wp config init`, then edit with `wp config edit`:
 
 The order of workspaces matches your Spaces order (left to right).
 
-For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. To start from your current macOS layout, run `wp snapshot`; it writes one starter zone per Space, with optional window comments via `wp snapshot --include-windows`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`.
+For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. Extra build arguments are forwarded to the TSX file, so a recipe can parse `Bun.argv.slice(2)` and expose variants such as `wp build --set quick`. To start from your current macOS layout, run `wp snapshot`; it writes one starter zone per Space, with optional window comments via `wp snapshot --include-windows`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`.
 
 ## Resolution presets
 
@@ -125,7 +126,7 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 ```bash
 gh repo clone KnickKnackLabs/wallpapers
 cd wallpapers && mise trust && mise install
-mise run test   # 27 tests
+mise run test   # 29 tests
 ```
 
 **Architecture:** Swift layer (`Sources/WallpaperKit/`) handles Core Graphics rendering. Bash tasks in `.mise/tasks/` handle user interaction via `gum`. Shared helpers live in `lib/common.sh`. Space management delegates to [butthair](https://github.com/KnickKnackLabs/butthair).

--- a/README.tsx
+++ b/README.tsx
@@ -122,6 +122,7 @@ wp --all          # Apply wallpapers to all spaces from config
 wp quick          # Quick one-off wallpaper for current space
 wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
+wp build --set quick  # Pass arguments to WALLPAPERS.tsx
 wp apply --config ./WALLPAPERS.json --wallpapers
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
@@ -152,7 +153,9 @@ wp goto -         # Go back to previous workspace`}</CodeBlock>
 
       <Paragraph>
         For repo-owned recipes, write <Code>WALLPAPERS.tsx</Code>, then run{" "}
-        <Code>wp build</Code>. To start from your current macOS layout, run{" "}
+        <Code>wp build</Code>. Extra build arguments are forwarded to the TSX file, so a
+        recipe can parse <Code>Bun.argv.slice(2)</Code> and expose variants such as{" "}
+        <Code>wp build --set quick</Code>. To start from your current macOS layout, run{" "}
         <Code>wp snapshot</Code>; it writes one starter zone per Space, with optional window
         comments via <Code>wp snapshot --include-windows</Code>. The generated{" "}
         <Code>WALLPAPERS.json</Code> can be applied explicitly with{" "}

--- a/test/build.bats
+++ b/test/build.bats
@@ -68,6 +68,18 @@ TSX
   [[ "$output" == *"WALLPAPERS.json is missing"* ]]
 }
 
+@test "build ignores inherited usage variables from parent mise sessions" {
+  write_recipe
+
+  usage_check=true usage_out=stale.json usage_source=missing.tsx run wallpapers build
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"source: $CALLER_PWD/WALLPAPERS.tsx"* ]]
+  [[ "$output" == *"out:    $CALLER_PWD/WALLPAPERS.json"* ]]
+  [ -f "$CALLER_PWD/WALLPAPERS.json" ]
+  [ ! -e "$CALLER_PWD/stale.json" ]
+}
+
 @test "build accepts explicit source and output paths relative to caller" {
   mkdir -p "$CALLER_PWD/recipes"
   cat > "$CALLER_PWD/recipes/small.tsx" <<'TSX'
@@ -89,4 +101,40 @@ TSX
 
   run jq -r '.spaces[0].zones[0].name' "$CALLER_PWD/.wallpapers/small.json"
   [ "$output" = "one" ]
+}
+
+@test "build passes remaining arguments to WALLPAPERS.tsx" {
+  cat > "$CALLER_PWD/WALLPAPERS.tsx" <<'TSX'
+import { parseArgs } from "util";
+import { WorkspaceSet, Space, Zone } from "wallpapers";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    set: { type: "string", default: "quick" },
+  },
+  strict: true,
+});
+
+const sets = {
+  quick: (
+    <WorkspaceSet name="quick">
+      <Space name="quick"><Zone name="quick" /></Space>
+    </WorkspaceSet>
+  ),
+  brownie: (
+    <WorkspaceSet name="brownie">
+      <Space name="brownie"><Zone name="brownie" /></Space>
+    </WorkspaceSet>
+  ),
+};
+
+export default sets[values.set as keyof typeof sets];
+TSX
+
+  run wallpapers build --set brownie
+
+  [ "$status" -eq 0 ]
+  run jq -r '.name' "$CALLER_PWD/WALLPAPERS.json"
+  [ "$output" = "brownie" ]
 }

--- a/tsx-runtime/build.ts
+++ b/tsx-runtime/build.ts
@@ -8,17 +8,22 @@ type Options = {
   source?: string;
   out?: string;
   check: boolean;
+  recipeArgs: string[];
 };
 
 function usage(): never {
-  console.error("Usage: build.ts --source <WALLPAPERS.tsx> --out <WALLPAPERS.json> [--check]");
+  console.error("Usage: build.ts --source <WALLPAPERS.tsx> --out <WALLPAPERS.json> [--check] [-- <args...>]");
   process.exit(2);
 }
 
 function parseArgs(argv: string[]): Options {
-  const options: Options = { check: false };
+  const options: Options = { check: false, recipeArgs: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === "--") {
+      options.recipeArgs = argv.slice(i + 1);
+      break;
+    }
     switch (arg) {
       case "--source":
         i += 1;
@@ -49,6 +54,10 @@ function parseArgs(argv: string[]): Options {
 const options = parseArgs(process.argv.slice(2));
 const source = resolve(options.source!);
 const out = resolve(options.out!);
+
+const recipeArgv = [Bun.argv[0] ?? "bun", source, ...options.recipeArgs];
+(Bun as unknown as { argv: string[] }).argv = recipeArgv;
+process.argv = recipeArgv;
 
 const mod = await import(pathToFileURL(source).href);
 const exported = mod.default ?? mod.workspaceSet ?? mod.config;


### PR DESCRIPTION
## Summary

- forward extra `wp build` arguments to `WALLPAPERS.tsx` via `Bun.argv.slice(2)`, matching the `emails compose` TSX pattern
- parse `build`'s own flags from the actual argv instead of inherited `usage_*` env vars
- document `wp build --set quick` as recipe-owned argument handling

This means the tool only forwards args; each TSX file defines what flags like `--set quick` mean.

## Verification

- `mise run test` (29/29)
- `swift test` (5/5)
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`
- `bash -n .mise/tasks/build test/build.bats`
- `shellcheck -x .mise/tasks/build`
- `git diff --check`
- `mise run readme`
