### PR TITLE
Add missing Spaces during apply

### DIFF
--- a/.mise/tasks/apply/_default
+++ b/.mise/tasks/apply/_default
@@ -7,21 +7,34 @@
 #USAGE flag "--apps" help="Only launch and position apps"
 #USAGE flag "--config <config>" help="Config file to apply (default: ~/.config/wallpapers/config.json)"
 #USAGE flag "--clean" help="Close previous app windows before applying"
+#USAGE flag "--yes" help="Approve Space count changes or mismatch continuation without prompting"
+#USAGE flag "-y" help="Alias for --yes"
 set -euo pipefail
 source "${MISE_CONFIG_ROOT}/lib/common.sh"
+
+BUTTHAIR="${BUTTHAIR:-butthair}"
+GUM="${GUM:-gum}"
+SWIFT="${SWIFT:-swift}"
+OSASCRIPT="${OSASCRIPT:-osascript}"
+PGREP="${PGREP:-pgrep}"
+HS_CLI="${HS_CLI:-/Applications/Hammerspoon.app/Contents/Frameworks/hs/hs}"
+
+YES=false
+if [ "${usage_yes:-false}" = "true" ] || [ "${usage_y:-false}" = "true" ]; then
+    YES=true
+fi
 
 if [ -n "${usage_config:-}" ]; then
     WALLPAPERS_CONFIG_FILE=$(wallpapers_resolve_path "$usage_config")
 fi
 
 require_config "$WALLPAPERS_CONFIG_FILE"
-require_command butthair "Install with: shiv install butthair"
+require_command "$BUTTHAIR" "Install with: shiv install butthair"
+require_command "$GUM"
 
 # Require Hammerspoon via butthair
-APP_PATH="/Applications/Hammerspoon.app"
-HS_CLI="$APP_PATH/Contents/Frameworks/hs/hs"
-if [ ! -x "$HS_CLI" ] || ! pgrep -x "Hammerspoon" > /dev/null; then
-    gum style --foreground 196 "❌ Hammerspoon not running. Run: butthair setup"
+if [ ! -x "$HS_CLI" ] || ! "$PGREP" -x "Hammerspoon" > /dev/null; then
+    "$GUM" style --foreground 196 "❌ Hammerspoon not running. Run: butthair setup"
     exit 1
 fi
 
@@ -32,6 +45,96 @@ if [ "${usage_wallpapers:-}" = "true" ] || [ "${usage_apps:-}" = "true" ]; then
     DO_WALLPAPERS="${usage_wallpapers:-false}"
     DO_APPS="${usage_apps:-false}"
 fi
+
+is_interactive() {
+    [ -t 0 ] && [ -t 1 ]
+}
+
+confirm_or_require_yes() {
+    local prompt="$1"
+
+    if [ "$YES" = "true" ]; then
+        return 0
+    fi
+
+    if ! is_interactive; then
+        "$GUM" style --foreground 196 "❌ Confirmation required"
+        echo "$prompt"
+        echo "Re-run with --yes (or -y) to approve this non-interactively."
+        exit 2
+    fi
+
+    "$GUM" confirm "$prompt"
+}
+
+space_count() {
+    local count
+    if ! count=$("$BUTTHAIR" spaces:list -- -j 2>/dev/null | jq 'length'); then
+        "$GUM" style --foreground 196 "❌ Could not get space count from butthair"
+        exit 1
+    fi
+    if [ -z "$count" ] || [ "$count" = "0" ]; then
+        "$GUM" style --foreground 196 "❌ Could not get space count from butthair"
+        exit 1
+    fi
+    printf '%s\n' "$count"
+}
+
+add_spaces() {
+    local missing="$1"
+    local i=1
+    local output
+
+    while [ "$i" -le "$missing" ]; do
+        if ! output=$("$BUTTHAIR" spaces:add < /dev/null 2>&1); then
+            "$GUM" style --foreground 196 "❌ Failed to add Space $i/$missing"
+            echo "$output"
+            exit 1
+        fi
+        if [[ "$output" == error:* ]]; then
+            "$GUM" style --foreground 196 "❌ Failed to add Space $i/$missing"
+            echo "$output"
+            exit 1
+        fi
+        echo "  added space $i/$missing: $output"
+        sleep 0.3
+        i=$((i + 1))
+    done
+}
+
+reconcile_space_count() {
+    local config_count="$1"
+    local actual_count="$2"
+    local diff
+
+    if [ "$config_count" -gt "$actual_count" ]; then
+        diff=$((config_count - actual_count))
+        "$GUM" style --foreground 226 "⚠️  Config has $config_count workspaces, but macOS has $actual_count Spaces"
+        "$GUM" style --foreground 245 "wallpapers can add $diff Space(s) before applying."
+        echo ""
+        if ! confirm_or_require_yes "Add $diff Space(s) now?"; then
+            exit 0
+        fi
+        add_spaces "$diff"
+        actual_count=$(space_count)
+        if [ "$actual_count" -lt "$config_count" ]; then
+            "$GUM" style --foreground 196 "❌ Expected $config_count Spaces after adding, but macOS has $actual_count"
+            exit 1
+        fi
+    fi
+
+    if [ "$config_count" -lt "$actual_count" ]; then
+        diff=$((actual_count - config_count))
+        "$GUM" style --foreground 226 "⚠️  Config has $config_count workspaces, but macOS has $actual_count Spaces"
+        "$GUM" style --foreground 245 "wallpapers will apply the first $config_count wallpaper(s) and leave $diff extra Space(s) unchanged."
+        echo ""
+        if ! confirm_or_require_yes "Continue with $diff extra Space(s) unchanged?"; then
+            exit 0
+        fi
+    fi
+
+    SPACE_COUNT="$actual_count"
+}
 
 # Alternate wallpaper filename suffix to bust macOS cache.
 cache_bust() {
@@ -54,36 +157,12 @@ SCREEN_H=$(resolution_height "$SCREEN_RES")
 {
     CONFIG_COUNT=$(jq 'if .spaces then .spaces | length elif .workspaces then .workspaces | length else 0 end' "$WALLPAPERS_CONFIG_FILE")
 
-    SPACE_COUNT=$(butthair spaces:list -- -j 2>/dev/null | jq 'length')
-    if [ -z "$SPACE_COUNT" ] || [ "$SPACE_COUNT" = "0" ]; then
-        gum style --foreground 196 "❌ Could not get space count from butthair"
-        exit 1
-    fi
-
-    if [ "$CONFIG_COUNT" -ne "$SPACE_COUNT" ]; then
-        gum style --foreground 226 "⚠️  Mismatch: config has $CONFIG_COUNT workspaces, but you have $SPACE_COUNT spaces"
-        echo ""
-        if [ "$CONFIG_COUNT" -gt "$SPACE_COUNT" ]; then
-            DIFF=$((CONFIG_COUNT - SPACE_COUNT))
-            gum style --foreground 245 "To add $DIFF space(s):"
-            echo "  1. Open Mission Control (Ctrl+Up or swipe up with 3 fingers)"
-            echo "  2. Hover over the top row and click the '+' button"
-            echo "  3. Repeat until you have $CONFIG_COUNT spaces"
-        else
-            DIFF=$((SPACE_COUNT - CONFIG_COUNT))
-            gum style --foreground 245 "You have $DIFF extra space(s). Either:"
-            echo "  • Add more workspaces to your config: wp config edit"
-            echo "  • Or remove spaces: Mission Control → hover space → click X"
-        fi
-        echo ""
-        if ! gum confirm "Continue anyway?"; then
-            exit 0
-        fi
-    fi
+    SPACE_COUNT=$(space_count)
+    reconcile_space_count "$CONFIG_COUNT" "$SPACE_COUNT"
 
     # --- Wallpapers ---
     if [ "$DO_WALLPAPERS" = "true" ]; then
-        OUTPUT=$(swift run setup -- --config "$WALLPAPERS_CONFIG_FILE" --width "$SCREEN_W" --height "$SCREEN_H")
+        OUTPUT=$("$SWIFT" run setup -- --config "$WALLPAPERS_CONFIG_FILE" --width "$SCREEN_W" --height "$SCREEN_H")
         FILES=()
         while IFS= read -r line; do
             if [[ "$line" == FILE:* ]]; then
@@ -94,34 +173,34 @@ SCREEN_H=$(resolution_height "$SCREEN_RES")
         done <<< "$OUTPUT"
 
         if [ ${#FILES[@]} -eq 0 ]; then
-            gum style --foreground 196 "❌ No wallpapers to apply"
+            "$GUM" style --foreground 196 "❌ No wallpapers to apply"
             exit 1
         fi
 
-        gum style --foreground 245 "Applying ${#FILES[@]} wallpaper(s) to spaces..."
+        "$GUM" style --foreground 245 "Applying ${#FILES[@]} wallpaper(s) to spaces..."
 
-        CURRENT_SPACE=$(butthair spaces:current -- -i 2>/dev/null)
+        CURRENT_SPACE=$("$BUTTHAIR" spaces:current -- -i 2>/dev/null)
 
         for i in "${!FILES[@]}"; do
             FILE="${FILES[$i]}"
             TARGET_SPACE=$((i + 1))
-            butthair spaces:goto -- "$TARGET_SPACE" < /dev/null 2>/dev/null
+            "$BUTTHAIR" spaces:goto -- "$TARGET_SPACE" < /dev/null 2>/dev/null
             sleep 0.3
             SUFFIXED=$(cache_bust "$FILE")
             cp "$FILE" "$SUFFIXED"
             echo "  wallpaper $((i+1))/${#FILES[@]}: $(basename "$SUFFIXED")"
-            osascript -e "tell application \"System Events\" to set picture of current desktop to \"$SUFFIXED\""
+            "$OSASCRIPT" -e "tell application \"System Events\" to set picture of current desktop to \"$SUFFIXED\""
             sleep 0.3
         done
 
-        butthair spaces:goto -- "$CURRENT_SPACE" < /dev/null 2>/dev/null
-        gum style --foreground 46 "✅ Wallpapers applied"
+        "$BUTTHAIR" spaces:goto -- "$CURRENT_SPACE" < /dev/null 2>/dev/null
+        "$GUM" style --foreground 46 "✅ Wallpapers applied"
     fi
 
     # --- Apps ---
     if [ "$DO_APPS" = "true" ]; then
         # Get screen usable area from Hammerspoon (accounts for menu bar)
-        SCREEN_JSON=$(butthair screen:info -- -j 2>/dev/null)
+        SCREEN_JSON=$("$BUTTHAIR" screen:info -- -j 2>/dev/null)
         USABLE_W=$(echo "$SCREEN_JSON" | jq '.usable.w')
         USABLE_H=$(echo "$SCREEN_JSON" | jq '.usable.h')
         USABLE_Y=$(echo "$SCREEN_JSON" | jq '.usable.y')
@@ -131,12 +210,12 @@ SCREEN_H=$(resolution_height "$SCREEN_RES")
         STATE_FILE="$HOME/.local/share/wallpapers/.apply-state"
         mkdir -p "$(dirname "$STATE_FILE")"
 
-        CURRENT_SPACE=$(butthair spaces:current -- -i 2>/dev/null)
+        CURRENT_SPACE=$("$BUTTHAIR" spaces:current -- -i 2>/dev/null)
 
         # Optionally close previous windows first
         if [ "${usage_clean:-false}" = "true" ] && [ -f "$STATE_FILE" ] && [ -s "$STATE_FILE" ]; then
             PREV_COUNT=$(grep -c . "$STATE_FILE")
-            gum style --foreground 245 "Closing $PREV_COUNT previous window(s)..."
+            "$GUM" style --foreground 245 "Closing $PREV_COUNT previous window(s)..."
             PREV_SPACES=()
             PREV_WINS=()
             while IFS= read -r line; do
@@ -147,20 +226,20 @@ SCREEN_H=$(resolution_height "$SCREEN_RES")
             PREV_LAST_SPACE=""
             for i in "${!PREV_WINS[@]}"; do
                 if [ "${PREV_SPACES[$i]}" != "$PREV_LAST_SPACE" ]; then
-                    if ! butthair spaces:goto -- "${PREV_SPACES[$i]}" < /dev/null 2>/dev/null; then
+                    if ! "$BUTTHAIR" spaces:goto -- "${PREV_SPACES[$i]}" < /dev/null 2>/dev/null; then
                         : # Window cleanup is best-effort; continue closing what we can.
                     fi
                     sleep 0.3
                     PREV_LAST_SPACE="${PREV_SPACES[$i]}"
                 fi
-                if ! butthair windows:close -- "${PREV_WINS[$i]}" < /dev/null 2>/dev/null; then
+                if ! "$BUTTHAIR" windows:close -- "${PREV_WINS[$i]}" < /dev/null 2>/dev/null; then
                     : # Window may already be gone.
                 fi
             done
         fi
         : > "$STATE_FILE"
 
-        gum style --foreground 245 "Positioning apps..."
+        "$GUM" style --foreground 245 "Positioning apps..."
 
         for s in $(seq 0 $((CONFIG_COUNT - 1))); do
             SPACE_NUM=$((s + 1))
@@ -172,7 +251,7 @@ SCREEN_H=$(resolution_height "$SCREEN_RES")
             [ "$TOTAL_APPS" -eq 0 ] && continue
 
             # Navigate to this space
-            butthair spaces:goto -- "$SPACE_NUM" < /dev/null 2>/dev/null
+            "$BUTTHAIR" spaces:goto -- "$SPACE_NUM" < /dev/null 2>/dev/null
             sleep 0.5
 
             # Zone bounds math (matches WallpaperKit/Generator.swift)
@@ -269,8 +348,8 @@ return tostring(win:id())
             done
         done
 
-        butthair spaces:goto -- "$CURRENT_SPACE" < /dev/null 2>/dev/null
-        gum style --foreground 46 "✅ Apps positioned"
+        "$BUTTHAIR" spaces:goto -- "$CURRENT_SPACE" < /dev/null 2>/dev/null
+        "$GUM" style --foreground 46 "✅ Apps positioned"
     fi
 
 }

--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#MISE description="Run codebase convention lints"
+set -euo pipefail
+
+rules=(
+  mise-settings
+  bats-test-task
+  bats-test-helper
+  mcr-scope
+  or-true
+  shellcheck
+  gum-table
+)
+
+failures=0
+for rule in "${rules[@]}"; do
+  echo "[lint:$rule]"
+  if ! codebase "lint:$rule" "$MISE_CONFIG_ROOT"; then
+    failures=$((failures + 1))
+  fi
+  echo ""
+done
+
+if [ "$failures" -gt 0 ]; then
+  echo "codebase lint failed: $failures rule(s)" >&2
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This tool generates wallpapers with labels so you can tell them apart.
 
 ![lang: Swift + Bash](https://img.shields.io/badge/lang-Swift%20%2B%20Bash-F05138?style=flat&logo=swift&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tasks: 22](https://img.shields.io/badge/tasks-22-blue?style=flat)
-![tests: 29](https://img.shields.io/badge/tests-29-green?style=flat)
+![tasks: 23](https://img.shields.io/badge/tasks-23-blue?style=flat)
+![tests: 33](https://img.shields.io/badge/tests-33-green?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -53,6 +53,7 @@ wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
 wp build --set quick  # Pass arguments to WALLPAPERS.tsx
 wp apply --config ./WALLPAPERS.json --wallpapers
+wp apply --config ./WALLPAPERS.json --wallpapers --yes  # Add missing Spaces non-interactively
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
 wp goto -         # Go back to previous workspace
@@ -78,7 +79,7 @@ Create your config with `wp config init`, then edit with `wp config edit`:
 
 The order of workspaces matches your Spaces order (left to right).
 
-For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. Extra build arguments are forwarded to the TSX file, so a recipe can parse `Bun.argv.slice(2)` and expose variants such as `wp build --set quick`. To start from your current macOS layout, run `wp snapshot`; it writes one starter zone per Space, with optional window comments via `wp snapshot --include-windows`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`.
+For repo-owned recipes, write `WALLPAPERS.tsx`, then run `wp build`. Extra build arguments are forwarded to the TSX file, so a recipe can parse `Bun.argv.slice(2)` and expose variants such as `wp build --set quick`. To start from your current macOS layout, run `wp snapshot`; it writes one starter zone per Space, with optional window comments via `wp snapshot --include-windows`. The generated `WALLPAPERS.json` can be applied explicitly with `wp apply --config ./WALLPAPERS.json --wallpapers`. If the config has more workspaces than macOS has Spaces, `wp apply` can add the missing Spaces after interactive confirmation; headless callers must pass `--yes` (or `-y`) instead of relying on a prompt.
 
 ## Resolution presets
 
@@ -114,6 +115,7 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 | `info:resolution` | Show your screen resolution |
 | `info:space` | Show current desktop space |
 | `info:wallpaper` | Show current wallpaper file path |
+| `lint` | Run codebase convention lints |
 | `open` | Open the wallpapers directory in Finder |
 | `quick` | Quick generate with just a name (auto-detects screen resolution) |
 | `readme` | Regenerate README.md from README.tsx |
@@ -126,7 +128,7 @@ Auto-detect is the default. You can also specify a preset with `--resolution`:
 ```bash
 gh repo clone KnickKnackLabs/wallpapers
 cd wallpapers && mise trust && mise install
-mise run test   # 29 tests
+mise run test   # 33 tests
 ```
 
 **Architecture:** Swift layer (`Sources/WallpaperKit/`) handles Core Graphics rendering. Bash tasks in `.mise/tasks/` handle user interaction via `gum`. Shared helpers live in `lib/common.sh`. Space management delegates to [butthair](https://github.com/KnickKnackLabs/butthair).

--- a/README.tsx
+++ b/README.tsx
@@ -124,6 +124,7 @@ wp snapshot       # Bootstrap WALLPAPERS.tsx from current Spaces
 wp build          # Compile WALLPAPERS.tsx to WALLPAPERS.json
 wp build --set quick  # Pass arguments to WALLPAPERS.tsx
 wp apply --config ./WALLPAPERS.json --wallpapers
+wp apply --config ./WALLPAPERS.json --wallpapers --yes  # Add missing Spaces non-interactively
 wp goto           # Switch workspace (picker)
 wp goto code      # Switch to workspace by name
 wp goto -         # Go back to previous workspace`}</CodeBlock>
@@ -159,7 +160,10 @@ wp goto -         # Go back to previous workspace`}</CodeBlock>
         <Code>wp snapshot</Code>; it writes one starter zone per Space, with optional window
         comments via <Code>wp snapshot --include-windows</Code>. The generated{" "}
         <Code>WALLPAPERS.json</Code> can be applied explicitly with{" "}
-        <Code>wp apply --config ./WALLPAPERS.json --wallpapers</Code>.
+        <Code>wp apply --config ./WALLPAPERS.json --wallpapers</Code>. If the config has
+        more workspaces than macOS has Spaces, <Code>wp apply</Code> can add the missing
+        Spaces after interactive confirmation; headless callers must pass <Code>--yes</Code>{" "}
+        (or <Code>-y</Code>) instead of relying on a prompt.
       </Paragraph>
     </Section>
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,9 +2,11 @@
 # Shared constants and helpers for wallpapers tasks.
 
 # Paths
+# shellcheck disable=SC2034 # Shared constant for tasks that source this file.
 WALLPAPERS_OUTPUT_DIR="$HOME/.local/share/wallpapers"
 WALLPAPERS_CONFIG_DIR="$HOME/.config/wallpapers"
 WALLPAPERS_CONFIG_FILE="$WALLPAPERS_CONFIG_DIR/config.json"
+# shellcheck disable=SC2034 # Shared constant for tasks that source this file.
 WALLPAPERS_STATE_DIR="$HOME/.local/state/wallpapers"
 
 # Return the directory where the user invoked wallpapers.
@@ -36,7 +38,7 @@ wallpapers_resolve_path() {
 # Outputs WxH (e.g. "3024x1964"). Returns 1 if detection fails.
 detect_screen_resolution() {
   local res
-  res=$(system_profiler SPDisplaysDataType 2>/dev/null \
+  res=$("${SYSTEM_PROFILER:-system_profiler}" SPDisplaysDataType 2>/dev/null \
     | grep -i "Resolution:" \
     | head -1 \
     | sed 's/.*: //' \

--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,6 @@ shellcheck = "0.11.0"
 "shiv:readme" = "latest"
 
 [_.codebase]
-lint = ["mise-settings", "bats-test-task", "bats-test-helper", "mcr-scope", "or-true", "shellcheck"]
+lint = ["mise-settings", "bats-test-task", "bats-test-helper", "mcr-scope", "or-true", "shellcheck", "gum-table"]
 
 # Note: Swift is built-in on macOS, no need to manage it

--- a/test/apply.bats
+++ b/test/apply.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+  CALLER_PWD="$BATS_TEST_TMPDIR/workspace"
+  export CALLER_PWD
+  mkdir -p "$CALLER_PWD"
+  setup_apply_mocks
+}
+
+setup_apply_mocks() {
+  MOCK_SPACE_COUNT="$BATS_TEST_TMPDIR/space-count"
+  MOCK_BUTTHAIR_LOG="$BATS_TEST_TMPDIR/butthair.log"
+  MOCK_OSASCRIPT_LOG="$BATS_TEST_TMPDIR/osascript.log"
+  MOCK_GENERATED_DIR="$BATS_TEST_TMPDIR/generated"
+  export MOCK_SPACE_COUNT MOCK_BUTTHAIR_LOG MOCK_OSASCRIPT_LOG MOCK_GENERATED_DIR
+  printf '1\n' > "$MOCK_SPACE_COUNT"
+  : > "$MOCK_BUTTHAIR_LOG"
+  : > "$MOCK_OSASCRIPT_LOG"
+  mkdir -p "$MOCK_GENERATED_DIR"
+
+  BUTTHAIR="$BATS_TEST_TMPDIR/butthair"
+  GUM="$BATS_TEST_TMPDIR/gum"
+  SWIFT="$BATS_TEST_TMPDIR/swift"
+  OSASCRIPT="$BATS_TEST_TMPDIR/osascript"
+  SYSTEM_PROFILER="$BATS_TEST_TMPDIR/system_profiler"
+  PGREP="$BATS_TEST_TMPDIR/pgrep"
+  HS_CLI="$BATS_TEST_TMPDIR/hs"
+  export BUTTHAIR GUM SWIFT OSASCRIPT SYSTEM_PROFILER PGREP HS_CLI
+
+  cat > "$BUTTHAIR" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${MOCK_BUTHAIR_LOG:-${MOCK_BUTTHAIR_LOG:?}}"
+count=$(cat "${MOCK_SPACE_COUNT:?}")
+spaces_json() {
+  local n="$1"
+  printf '['
+  local i=1
+  while [ "$i" -le "$n" ]; do
+    [ "$i" -gt 1 ] && printf ','
+    printf '{"id":%s,"active":%s,"type":"user","index":%s}' "$((1000 + i))" "$([ "$i" -eq 1 ] && echo true || echo false)" "$i"
+    i=$((i + 1))
+  done
+  printf ']\n'
+}
+case "${1:-}" in
+  "spaces:list")
+    spaces_json "$count"
+    ;;
+  "spaces:add")
+    if [ -n "${MOCK_ADD_ERROR_ONCE:-}" ] && [ ! -f "${MOCK_ADD_ERROR_ONCE}.used" ]; then
+      : > "${MOCK_ADD_ERROR_ONCE}.used"
+      echo "error: unable to get Mission Control data from the Dock"
+      exit 0
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "${MOCK_SPACE_COUNT:?}"
+    echo "added space #$count (id=$((1000 + count)))"
+    ;;
+  "spaces:current")
+    echo "1"
+    ;;
+  "spaces:goto")
+    target=""
+    for arg in "$@"; do target="$arg"; done
+    echo "switched to space #$target"
+    ;;
+  "screen:info")
+    echo '{"usable":{"w":1200,"h":800,"y":24}}'
+    ;;
+  "windows:close")
+    target=""
+    for arg in "$@"; do target="$arg"; done
+    echo "closed $target"
+    ;;
+  *)
+    echo "unexpected butthair call: $*" >&2
+    exit 99
+    ;;
+esac
+BASH
+
+  cat > "$GUM" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  style)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --foreground|--border|--padding|--margin|--align|--width)
+          shift 2
+          ;;
+        --bold|--print|--)
+          shift
+          ;;
+        *)
+          printf '%s ' "$1"
+          shift
+          ;;
+      esac
+    done
+    printf '\n'
+    ;;
+  confirm)
+    echo "unexpected interactive confirmation: ${*:2}" >&2
+    exit 99
+    ;;
+  *)
+    echo "unexpected gum call: $*" >&2
+    exit 99
+    ;;
+esac
+BASH
+
+  cat > "$SWIFT" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+config=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--config" ]; then
+    shift
+    config="$1"
+  fi
+  shift || true
+done
+count=$(jq 'if .spaces then .spaces | length elif .workspaces then .workspaces | length else 0 end' "$config")
+mkdir -p "${MOCK_GENERATED_DIR:?}"
+i=1
+while [ "$i" -le "$count" ]; do
+  file="$MOCK_GENERATED_DIR/wallpaper-$i.png"
+  printf 'png-%s\n' "$i" > "$file"
+  echo "[$i/$count] Generating: test-$i"
+  echo "FILE:$file"
+  i=$((i + 1))
+done
+echo "MODE:apply"
+BASH
+
+  cat > "$OSASCRIPT" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${MOCK_OSASCRIPT_LOG:?}"
+BASH
+
+  cat > "$SYSTEM_PROFILER" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo '    Resolution: 1920 x 1080 Retina'
+BASH
+
+  cat > "$PGREP" <<'BASH'
+#!/usr/bin/env bash
+exit 0
+BASH
+
+  cat > "$HS_CLI" <<'BASH'
+#!/usr/bin/env bash
+exit 0
+BASH
+
+  chmod +x "$BUTTHAIR" "$GUM" "$SWIFT" "$OSASCRIPT" "$SYSTEM_PROFILER" "$PGREP" "$HS_CLI"
+}
+
+write_spaces_config() {
+  local path="$1"
+  local count="$2"
+  {
+    printf '{"schemaVersion":1,"spaces":['
+    local i=1
+    while [ "$i" -le "$count" ]; do
+      [ "$i" -gt 1 ] && printf ','
+      printf '{"name":"space-%s","zones":[{"name":"zone-%s"}]}' "$i" "$i"
+      i=$((i + 1))
+    done
+    printf '],"defaults":{"bgColor":"#000000","textColor":"#ffffff"}}\n'
+  } > "$path"
+}
+
+@test "apply refuses to add Spaces non-interactively without --yes" {
+  config="$CALLER_PWD/two-spaces.json"
+  write_spaces_config "$config" 2
+  printf '1\n' > "$MOCK_SPACE_COUNT"
+
+  run wallpapers apply --config "$config" --wallpapers
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Confirmation required"* ]]
+  [[ "$output" == *"Re-run with --yes (or -y)"* ]]
+  [ "$(cat "$MOCK_SPACE_COUNT")" = "1" ]
+  if grep -q "spaces:add" "$MOCK_BUTTHAIR_LOG"; then
+    echo "unexpected spaces:add call" >&2
+    return 1
+  fi
+}
+
+@test "apply --yes adds missing Spaces before applying wallpapers" {
+  config="$CALLER_PWD/three-spaces.json"
+  write_spaces_config "$config" 3
+  printf '1\n' > "$MOCK_SPACE_COUNT"
+
+  run wallpapers apply --config "$config" --wallpapers --yes
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"added space 1/2"* ]]
+  [[ "$output" == *"added space 2/2"* ]]
+  [[ "$output" == *"Wallpapers applied"* ]]
+  [ "$(cat "$MOCK_SPACE_COUNT")" = "3" ]
+  [ "$(grep -c '^spaces:add$' "$MOCK_BUTTHAIR_LOG")" = "2" ]
+  grep -q "spaces:goto -- 1" "$MOCK_BUTTHAIR_LOG"
+  grep -q "spaces:goto -- 2" "$MOCK_BUTTHAIR_LOG"
+  grep -q "spaces:goto -- 3" "$MOCK_BUTTHAIR_LOG"
+  [ "$(wc -l < "$MOCK_OSASCRIPT_LOG" | tr -d ' ')" = "3" ]
+}
+
+@test "apply -y continues non-interactively with extra Spaces" {
+  config="$CALLER_PWD/one-space.json"
+  write_spaces_config "$config" 1
+  printf '2\n' > "$MOCK_SPACE_COUNT"
+
+  run wallpapers apply --config "$config" --wallpapers -y
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"leave 1 extra Space(s) unchanged"* ]]
+  [[ "$output" == *"Wallpapers applied"* ]]
+  if grep -q "spaces:add" "$MOCK_BUTTHAIR_LOG"; then
+    echo "unexpected spaces:add call" >&2
+    return 1
+  fi
+  [ "$(wc -l < "$MOCK_OSASCRIPT_LOG" | tr -d ' ')" = "1" ]
+}
+
+@test "apply fails when spaces:add returns an error string" {
+  config="$CALLER_PWD/two-spaces.json"
+  write_spaces_config "$config" 2
+  printf '1\n' > "$MOCK_SPACE_COUNT"
+  MOCK_ADD_ERROR_ONCE="$BATS_TEST_TMPDIR/add-error"
+  export MOCK_ADD_ERROR_ONCE
+
+  run wallpapers apply --config "$config" --wallpapers --yes
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to add Space 1/1"* ]]
+  [[ "$output" == *"error: unable to get Mission Control data from the Dock"* ]]
+  [ "$(cat "$MOCK_SPACE_COUNT")" = "1" ]
+  [ ! -s "$MOCK_OSASCRIPT_LOG" ]
+}


### PR DESCRIPTION
## Summary

- add `wp apply --yes` / `-y` as a headless-safe confirmation bypass
- when config needs more macOS Spaces than exist, confirm or require `--yes`, call `butthair spaces:add`, then re-count before applying
- when config has fewer spaces than macOS, gate the "continue with extra Spaces unchanged" path the same way
- add a local `mise run lint` wrapper for configured codebase lints and include `gum-table`
- document the apply behavior in README

## Verification

- `mise run test` (33/33)
- `swift test` (5/5)
- `mise exec -- readme build --check`
- `mise run lint`
- `bash -n` across `.mise/tasks` and `test`
- `shellcheck -x .mise/tasks/apply/_default .mise/tasks/lint lib/common.sh test/apply.bats`
- `git diff --check`

## Notes

This follows the new fold pattern `tty-confirmation-gate`: TTY humans can confirm interactively; non-TTY callers must pass `--yes` / `-y` so agents and CI never hang on gum prompts.
